### PR TITLE
Create initial Jekyll site for NeuroTrailblazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# NeuroTrailblazers
+
+This repository contains the source for the **NeuroTrailblazers** website. The site is built with [Jekyll](https://jekyllrb.com/) and is ready for GitHub Pages deployment.
+
+## Features
+- MERIT and COMPASS pedagogical frameworks
+- Modules with Bloom's Taxonomy learning objectives
+- Archetype mentors and dataset guides
+- Responsive design with a neural-inspired color palette
+
+## Development
+1. Install [Ruby](https://www.ruby-lang.org/) and the `bundler` gem.
+2. Run `bundle install` to install Jekyll and dependencies.
+3. Serve locally with `bundle exec jekyll serve`.
+
+Contributions welcome! This project emphasizes open science and community-driven improvements.

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,48 @@
 title: NeuroTrailblazers
 theme: minima
+minima:
+  include:
+    head: head-custom
 markdown: kramdown
 collections:
   mentors:
     output: true
     permalink: /mentors/:path/
+  modules:
+    output: true
+    permalink: /modules/:path/
+  archetypes:
+    output: true
+    permalink: /archetypes/:path/
+  datasets:
+    output: true
+    permalink: /datasets/:path/
+
+defaults:
+  - scope:
+      path: ""
+      type: modules
+    values:
+      layout: default
+  - scope:
+      path: ""
+      type: archetypes
+    values:
+      layout: default
+  - scope:
+      path: ""
+      type: datasets
+    values:
+      layout: default
+
+nav_items:
+  - title: "Start Here"
+    url: "/start-here"
+  - title: "Modules"
+    url: "/modules"
+  - title: "Datasets"
+    url: "/datasets"
+  - title: "Archetypes"
+    url: "/archetypes"
+  - title: "Models"
+    url: "/education/models"

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="/assets/css/site-styles.css">

--- a/archetypes/grad-student.md
+++ b/archetypes/grad-student.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Layla – Graduate Student
+---
+
+Layla is midway through her PhD focusing on synaptic plasticity. She juggles coursework, teaching, and research while seeking collaborations across disciplines.

--- a/archetypes/index.md
+++ b/archetypes/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Archetype Mentors
+---
+
+Meet our representative scientists. These archetypes serve as guides throughout the modules.

--- a/archetypes/postdoc-ai.md
+++ b/archetypes/postdoc-ai.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Elias – AI Postdoc
+---
+
+Elias develops machine learning tools for connectomics. He mentors others on data-driven methods and exemplifies the COMPASS focus on agency and mastery.

--- a/archetypes/undergrad-firstgen.md
+++ b/archetypes/undergrad-firstgen.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Julian – First-Gen Undergrad
+---
+
+Julian grew up in a rural town and is the first in his family to pursue science. He represents newcomers who are excited but uncertain. His journey mirrors the MERIT stages as he gains confidence in research skills.

--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -1,0 +1,49 @@
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  background-color: #fff;
+  color: #111827;
+}
+
+.hero {
+  padding: 4rem 1rem;
+  text-align: center;
+  background: linear-gradient(135deg, #2563eb, #7c3aed, #06b6d4);
+  color: white;
+}
+
+.hero .btn {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #fff;
+  color: #2563eb;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.feature {
+  border: 1px solid #e5e7eb;
+  padding: 1rem;
+  border-radius: 4px;
+  background: #f9fafb;
+  transition: transform 0.2s ease;
+}
+
+.feature:hover {
+  transform: scale(1.02);
+}
+
+@media (prefers-color-scheme: dark) {
+  body { background-color: #111827; color: #e5e7eb; }
+  .feature { background: #1f2937; border-color: #374151; }
+}

--- a/datasets/flywire.md
+++ b/datasets/flywire.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: FlyWire
+---
+
+FlyWire is a community effort to reconstruct the adult Drosophila brain. Data are openly accessible for annotation and exploration.

--- a/datasets/h01.md
+++ b/datasets/h01.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: H01 Human Cortex
+---
+
+H01 offers an unprecedented look at human cortical ultrastructure with open-source segmentation data.

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Datasets
+---
+
+Explore public connectomics datasets used in the modules.

--- a/datasets/microns.md
+++ b/datasets/microns.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: MICrONS
+---
+
+The MICrONS Explorer dataset provides a mouse visual cortex connectome with aligned physiology and EM data.

--- a/datasets/snemi3d.md
+++ b/datasets/snemi3d.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: SNEMI3D
+---
+
+SNEMI3D is a benchmarking challenge dataset for segmentation algorithms in EM.

--- a/education/models.md
+++ b/education/models.md
@@ -7,12 +7,15 @@ This section introduces two core training frameworks used throughout NeuroTrailb
 
 ### MERIT Model
 
-- Motivation → Knowledge → Skills → Character → Meta-Learning  
-- Each mapped across the research lifecycle: Foundations → Question → Experiment → Analysis → Dissemination
+- **M**entoring Exceptional Researchers to Innovate and Thrive. It follows the scientific method from merit-based selection through career transition.
+- Stages: Selection, Orientation, Skill Development, Independent Research, Advanced Research, Career Transition.
+- Anchored in evidence from Lopatto (2007) on undergraduate research experiences and Duckworth et al. (2007) on persistence.
 
 ### COMPASS Model
 
-- A learner-centered lens: Charting Opportunity, Mastery, Purpose, Agency, Skills, and Self
-- Emphasizes personal growth and scientific capability
+- Ten interactive workshops covering the hidden curriculum from orientation to future planning.
+- Integrates Fadel et al. (2015) four-dimensional education dimensions of knowledge, skills, character, and meta-learning.
+
+Both frameworks complement each other: MERIT structures your research journey while COMPASS offers workshops that develop resilience and professional habits.
 
 Visuals and downloadable guides coming soon.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+---
+layout: default
+title: NeuroTrailblazers
+---
+
+<div class="hero">
+  <h1>NeuroTrailblazers</h1>
+  <p class="tagline">Explore nanoscale connectomics with modern, evidence-based training.</p>
+  <a class="btn" href="start-here">Start Your Journey</a>
+</div>
+
+<section class="features">
+  <div class="feature-grid">
+    <div class="feature"><h2>Modules</h2><p>Step-by-step lessons aligned with Bloom's Taxonomy.</p></div>
+    <div class="feature"><h2>Datasets</h2><p>Work with real data from FlyWire, MICrONS, H01, and SNEMI3D.</p></div>
+    <div class="feature"><h2>Archetype Mentors</h2><p>Guidance from Julian, Layla, and Elias.</p></div>
+    <div class="feature"><h2>Frameworks</h2><p>MERIT and COMPASS support your growth as a researcher.</p></div>
+  </div>
+</section>
+

--- a/index.md
+++ b/index.md
@@ -1,9 +1,0 @@
----
-layout: default
-title: Start Here
----
-
-# Welcome to NeuroTrailblazers
-
-Explore the tools, stories, and skills that power modern neuroscience. Begin your journey with our [Start Here guide](start-here.md), or jump into a [Module](modules/module-1-intro/).
-

--- a/modules/index.md
+++ b/modules/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Learning Modules
+---
+
+Browse all modules below. Each includes SMART objectives and activities.

--- a/modules/module-0-inspiration/index.md
+++ b/modules/module-0-inspiration/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Module 0 – Inspiration
+---
+
+**Objective:** Reflect on why connectomics matters and set personal goals.
+
+- Watch example talks showcasing breakthroughs in nanoscale mapping.
+- Discuss how MERIT Stage 1 shapes your motivation.

--- a/modules/module-1-intro/index.md
+++ b/modules/module-1-intro/index.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Module 1 – Introduction to Connectomics
+---
+
+**SMART Objectives**
+- Identify components of the nervous system visible in EM data.
+- Explain the basic pipeline of segmentation and proofreading.
+
+Hands-on: open a Jupyter notebook in Binder to explore sample data.

--- a/modules/module-10/index.md
+++ b/modules/module-10/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 10
+---
+
+Content coming soon.

--- a/modules/module-11/index.md
+++ b/modules/module-11/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 11
+---
+
+Content coming soon.

--- a/modules/module-12/index.md
+++ b/modules/module-12/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 12
+---
+
+Content coming soon.

--- a/modules/module-13/index.md
+++ b/modules/module-13/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 13
+---
+
+Content coming soon.

--- a/modules/module-14/index.md
+++ b/modules/module-14/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 14
+---
+
+Content coming soon.

--- a/modules/module-15/index.md
+++ b/modules/module-15/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 15
+---
+
+Content coming soon.

--- a/modules/module-2/index.md
+++ b/modules/module-2/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 2
+---
+
+Content coming soon.

--- a/modules/module-3/index.md
+++ b/modules/module-3/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 3
+---
+
+Content coming soon.

--- a/modules/module-4/index.md
+++ b/modules/module-4/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 4
+---
+
+Content coming soon.

--- a/modules/module-5/index.md
+++ b/modules/module-5/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 5
+---
+
+Content coming soon.

--- a/modules/module-6/index.md
+++ b/modules/module-6/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 6
+---
+
+Content coming soon.

--- a/modules/module-7/index.md
+++ b/modules/module-7/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 7
+---
+
+Content coming soon.

--- a/modules/module-8/index.md
+++ b/modules/module-8/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 8
+---
+
+Content coming soon.

--- a/modules/module-9/index.md
+++ b/modules/module-9/index.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Module 9
+---
+
+Content coming soon.

--- a/scripts/chatbot.js
+++ b/scripts/chatbot.js
@@ -1,0 +1,2 @@
+// Placeholder for chatbot mentor integration
+console.log('Chatbot placeholder');

--- a/scripts/course-generator.js
+++ b/scripts/course-generator.js
@@ -1,0 +1,2 @@
+// Placeholder for course generation logic
+console.log('Course generator placeholder');

--- a/start-here.md
+++ b/start-here.md
@@ -3,8 +3,9 @@ layout: default
 title: Start Here
 ---
 
-Welcome to the **Start Here** guide. This orientation will help you:
+Welcome to the **Start Here** guide. This orientation walks you through the MERIT framework and helps you plan your path.
 
-1. Understand the connectomics research pipeline  
-2. Choose your starting point  
-3. Get matched to mentors and modules  
+1. **Understand the connectomics pipeline.** Learn how our Hi-MC workflow maps onto the MERIT stages from question formation to communication.
+2. **Select your starting point.** Whether you're new or experienced, the modules are organized so you can jump in where it makes sense.
+3. **Connect with mentors.** Our archetype mentors share tips for common challenges. Get paired with Julian, Layla, or Elias for guidance.
+4. **Track your progress.** Use the checklist at the end of each module to monitor your learning objectives.

--- a/workflow.md
+++ b/workflow.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Hi-MC Workflow
+---
+
+The **High-Information Morphological Connectomics (Hi-MC)** workflow guides you from raw EM images to publishable insights.
+
+1. **Acquisition** – collect or source data from public datasets like MICrONS or FlyWire.
+2. **Segmentation** – apply automated and manual techniques to define neurons.
+3. **Proofreading** – ensure accuracy through collaborative review.
+4. **Analysis** – quantify circuits using tools such as Python notebooks.
+5. **Dissemination** – share results and contribute to open science repositories.
+
+Each step aligns with MERIT:
+- **Stage 1–2**: Learn background and find mentors.
+- **Stage 3**: Develop segmentation and analysis skills.
+- **Stage 4–5**: Conduct independent experiments and network with experts.
+- **Stage 6**: Publish and plan your next career move.


### PR DESCRIPTION
## Summary
- add Jekyll collections for modules, datasets and archetypes
- include responsive hero landing page and CSS
- outline MERIT and COMPASS models, workflow and orientation
- add dataset guides and archetype mentor stories
- scaffold learning modules and basic scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886a2b8d508832da937f68ec86f08a4