### PR TITLE
Add module learning objectives

### DIFF
--- a/education/module-objectives.md
+++ b/education/module-objectives.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Module Learning Objectives
+---
+
+This page lists the learning objectives for each module in the NeuroTrailblazers series.
+
+## Module 1 – Introduction to Connectomics
+- Explain what a connectome is and why mapping neural circuits matters.
+- Describe the major steps in the connectomics research pipeline.
+- Identify core tools used for imaging, segmentation, and analysis.
+- Reflect on personal motivations for exploring connectomics.
+
+## Module 2 – Formulating Research Questions
+- Recognize gaps in current connectomics knowledge.
+- Translate broad interests into actionable research questions.
+- Apply the MERIT model to prioritize projects.
+- Draft a brief proposal outline with clear aims.
+
+## Module 3 – Experimental Techniques
+- Summarize methods for sample preparation and electron microscopy.
+- Compare imaging resolutions and trade-offs for different use cases.
+- Outline steps for data management and quality control.
+- Practice documenting protocols for reproducibility.
+
+## Module 4 – Data Analysis and Interpretation
+- Use basic Python notebooks to explore connectomics data sets.
+- Interpret segmentation outputs and common error modes.
+- Apply the COMPASS model to reflect on personal growth during analysis.
+- Communicate findings in figures and short reports.
+
+## Module 5 – Sharing and Collaborating
+- Describe open data principles and FAIR standards for connectomics.
+- Plan a short presentation for peers or the public.
+- Practice giving and receiving feedback on scientific communication.
+- Identify next steps for continued learning and mentorship.

--- a/index.md
+++ b/index.md
@@ -5,5 +5,10 @@ title: Start Here
 
 # Welcome to NeuroTrailblazers
 
-Explore the tools, stories, and skills that power modern neuroscience. Begin your journey with our [Start Here guide](start-here.md), or jump into a [Module](modules/module-1-intro/).
+Explore the tools, stories, and skills that power modern neuroscience. Begin your journey with our [Start Here guide](start-here.md), or browse the modules below.
 
+- [Module 1 – Introduction to Connectomics](modules/module-1-intro/)
+- [Module 2 – Formulating Research Questions](modules/module-2-question/)
+- [Module 3 – Experimental Techniques](modules/module-3-experiment/)
+- [Module 4 – Data Analysis and Interpretation](modules/module-4-analysis/)
+- [Module 5 – Sharing and Collaborating](modules/module-5-dissemination/)

--- a/modules/module-1-intro/index.md
+++ b/modules/module-1-intro/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Module 1 – Introduction to Connectomics
+---
+
+### Learning Objectives
+
+1. Explain what a connectome is and why mapping neural circuits matters.
+2. Describe the major steps in the connectomics research pipeline.
+3. Identify core tools used for imaging, segmentation, and analysis.
+4. Reflect on personal motivations for exploring connectomics.

--- a/modules/module-2-question/index.md
+++ b/modules/module-2-question/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Module 2 – Formulating Research Questions
+---
+
+### Learning Objectives
+
+1. Recognize gaps in current connectomics knowledge.
+2. Translate broad interests into actionable research questions.
+3. Apply the MERIT model to prioritize projects.
+4. Draft a brief proposal outline with clear aims.

--- a/modules/module-3-experiment/index.md
+++ b/modules/module-3-experiment/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Module 3 – Experimental Techniques
+---
+
+### Learning Objectives
+
+1. Summarize methods for sample preparation and electron microscopy.
+2. Compare imaging resolutions and trade-offs for different use cases.
+3. Outline steps for data management and quality control.
+4. Practice documenting protocols for reproducibility.

--- a/modules/module-4-analysis/index.md
+++ b/modules/module-4-analysis/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Module 4 – Data Analysis and Interpretation
+---
+
+### Learning Objectives
+
+1. Use basic Python notebooks to explore connectomics data sets.
+2. Interpret segmentation outputs and common error modes.
+3. Apply the COMPASS model to reflect on personal growth during analysis.
+4. Communicate findings in figures and short reports.

--- a/modules/module-5-dissemination/index.md
+++ b/modules/module-5-dissemination/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Module 5 – Sharing and Collaborating
+---
+
+### Learning Objectives
+
+1. Describe open data principles and FAIR standards for connectomics.
+2. Plan a short presentation for peers or the public.
+3. Practice giving and receiving feedback on scientific communication.
+4. Identify next steps for continued learning and mentorship.

--- a/start-here.md
+++ b/start-here.md
@@ -5,6 +5,8 @@ title: Start Here
 
 Welcome to the **Start Here** guide. This orientation will help you:
 
-1. Understand the connectomics research pipeline  
-2. Choose your starting point  
-3. Get matched to mentors and modules  
+1. Understand the connectomics research pipeline
+2. Choose your starting point
+3. Get matched to mentors and modules
+
+See the [learning objectives for each module](education/module-objectives.md) to plan your path.


### PR DESCRIPTION
## Summary
- create placeholder module pages with learning objectives
- link to modules from the homepage
- add module objectives summary page
- mention module objectives in the Start Here guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886a38feebc832da11beae607d27e4e