### PR TITLE
Add module grid and placeholders

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -232,6 +232,30 @@ body {
   font-size: 0.75rem;
 }
 
+.modules-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-bottom: 2rem;
+}
+.module-card {
+  background: var(--white);
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  padding: 1rem;
+}
+.module-number-link {
+  font-weight: 600;
+  color: var(--neural-blue);
+  text-decoration: none;
+}
+.module-number-link:hover {
+  text-decoration: underline;
+}
+.module-description {
+  color: #4b5563;
+  margin-top: 0.25rem;
+}
 .workflow-preview {
   display: flex;
   align-items: center;

--- a/modules/index.md
+++ b/modules/index.md
@@ -14,31 +14,33 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
 
 ### Module List with Descriptions
 
-1. **[Module 01](module01.md)** – *Scientific Curiosity & Motivation*: Orientation to scientific thinking, growth mindset, and curiosity-driven inquiry.
-2. **[Module 02](module02.md)** – *Research Foundations & the Hidden Curriculum*: Unwritten norms in science, research roles, and building confidence.
-3. **[Module 03](module03.md)** – *Python and Jupyter for Neuroscience*: Intro to coding in Python, Jupyter notebooks, and tools for analysis.
-4. **[Module 04](module04.md)** – *Neuroanatomy for Connectomics*: Understanding neural structure at micro- and macro-scale.
-5. **[Module 05](module05.md)** – *Electron Microscopy and Image Basics*: EM imaging principles, file formats, and interpretation.
-6. **[Module 06](module06.md)** – *Segmentation 101*: Understanding segmentation, labels, and sources of error.
-7. **[Module 07](module07.md)** – *Proofreading and Quality Control*: Identifying merge/split errors and assessing segmentation quality.
-8. **[Module 08](module08.md)** – *Hypothesis Testing in Connectomics*: Defining and testing hypotheses using statistical tools.
-9. **[Module 09](module09.md)** – *Neuron Morphology & Skeletonization*: Exploring cell shape, skeletons, and biofeatures.
-10. **[Module 10](module10.md)** – *Network Science & Graph Representation*: Introduction to graphs, adjacency, and connectome structure.
-11. **[Module 11](module11.md)** – *Synapses and Circuit Logic*: Mapping synaptic connectivity and interpreting motifs.
-12. **[Module 12](module12.md)** – *Big Data in Connectomics*: Storage, querying, and scale-aware design.
-13. **[Module 13](module13.md)** – *Machine Learning in Neuroscience*: Intro to ML concepts and supervised/unsupervised learning.
-14. **[Module 14](module14.md)** – *Computer Vision for EM*: From filters to deep learning for image understanding.
-15. **[Module 15](module15.md)** – *LLMs for Patch Analysis*: Using large language models for continuity, errors, and proofing.
-16. **[Module 16](module16.md)** – *Project-Based Research Planning*: Scoping, feasibility, and aligning skills with goals.
-17. **[Module 17](module17.md)** – *Experimental Design & Controls*: Establishing valid comparisons and controlling variables.
-18. **[Module 18](module18.md)** – *Data Cleaning and Preprocessing*: Handling noise, filtering data, and reproducibility.
-19. **[Module 19](module19.md)** – *Visualization for Insight*: Creating visualizations to explore and explain findings.
-20. **[Module 20](module20.md)** – *Statistical Models and Inference*: Modeling techniques to interpret neural data.
-21. **[Module 21](module21.md)** – *Reproducibility and FAIR Principles*: Ensuring research is findable, accessible, and reproducible.
-22. **[Module 22](module22.md)** – *Scientific Writing & Presentation*: Communicating ideas clearly with audience awareness.
-23. **[Module 23](module23.md)** – *Posters, Abstracts, and Conferences*: Sharing work with peers and professionals.
-24. **[Module 24](module24.md)** – *Career Pathways & Graduate School Prep*: Applying skills and navigating research careers.
-25. **[Module 25](module25.md)** – *Portfolio, Feedback, and Final Project*: Curating evidence of learning and capstone feedback.
+<div class="modules-grid">
+<div class="card module-card"><a href="module01.md" class="module-number-link">01. Scientific Curiosity & Motivation</a><p class="module-description">Orientation to scientific thinking, growth mindset, and curiosity-driven inquiry.</p></div>
+<div class="card module-card"><a href="module02.md" class="module-number-link">02. Research Foundations & the Hidden Curriculum</a><p class="module-description">Unwritten norms in science, research roles, and building confidence.</p></div>
+<div class="card module-card"><a href="module03.md" class="module-number-link">03. Python and Jupyter for Neuroscience</a><p class="module-description">Intro to coding in Python, Jupyter notebooks, and tools for analysis.</p></div>
+<div class="card module-card"><a href="module04.md" class="module-number-link">04. Neuroanatomy for Connectomics</a><p class="module-description">Understanding neural structure at micro- and macro-scale.</p></div>
+<div class="card module-card"><a href="module05.md" class="module-number-link">05. Electron Microscopy and Image Basics</a><p class="module-description">EM imaging principles, file formats, and interpretation.</p></div>
+<div class="card module-card"><a href="module06.md" class="module-number-link">06. Segmentation 101</a><p class="module-description">Understanding segmentation, labels, and sources of error.</p></div>
+<div class="card module-card"><a href="module07.md" class="module-number-link">07. Proofreading and Quality Control</a><p class="module-description">Identifying merge/split errors and assessing segmentation quality.</p></div>
+<div class="card module-card"><a href="module08.md" class="module-number-link">08. Hypothesis Testing in Connectomics</a><p class="module-description">Defining and testing hypotheses using statistical tools.</p></div>
+<div class="card module-card"><a href="module09.md" class="module-number-link">09. Neuron Morphology & Skeletonization</a><p class="module-description">Exploring cell shape, skeletons, and biofeatures.</p></div>
+<div class="card module-card"><a href="module10.md" class="module-number-link">10. Network Science & Graph Representation</a><p class="module-description">Introduction to graphs, adjacency, and connectome structure.</p></div>
+<div class="card module-card"><a href="module11.md" class="module-number-link">11. Synapses and Circuit Logic</a><p class="module-description">Mapping synaptic connectivity and interpreting motifs.</p></div>
+<div class="card module-card"><a href="module12.md" class="module-number-link">12. Big Data in Connectomics</a><p class="module-description">Storage, querying, and scale-aware design.</p></div>
+<div class="card module-card"><a href="module13.md" class="module-number-link">13. Machine Learning in Neuroscience</a><p class="module-description">Intro to ML concepts and supervised/unsupervised learning.</p></div>
+<div class="card module-card"><a href="module14.md" class="module-number-link">14. Computer Vision for EM</a><p class="module-description">From filters to deep learning for image understanding.</p></div>
+<div class="card module-card"><a href="module15.md" class="module-number-link">15. LLMs for Patch Analysis</a><p class="module-description">Using large language models for continuity, errors, and proofing.</p></div>
+<div class="card module-card"><a href="module16.md" class="module-number-link">16. Project-Based Research Planning</a><p class="module-description">Scoping, feasibility, and aligning skills with goals.</p></div>
+<div class="card module-card"><a href="module17.md" class="module-number-link">17. Experimental Design & Controls</a><p class="module-description">Establishing valid comparisons and controlling variables.</p></div>
+<div class="card module-card"><a href="module18.md" class="module-number-link">18. Data Cleaning and Preprocessing</a><p class="module-description">Handling noise, filtering data, and reproducibility.</p></div>
+<div class="card module-card"><a href="module19.md" class="module-number-link">19. Visualization for Insight</a><p class="module-description">Creating visualizations to explore and explain findings.</p></div>
+<div class="card module-card"><a href="module20.md" class="module-number-link">20. Statistical Models and Inference</a><p class="module-description">Modeling techniques to interpret neural data.</p></div>
+<div class="card module-card"><a href="module21.md" class="module-number-link">21. Reproducibility and FAIR Principles</a><p class="module-description">Ensuring research is findable, accessible, and reproducible.</p></div>
+<div class="card module-card"><a href="module22.md" class="module-number-link">22. Scientific Writing & Presentation</a><p class="module-description">Communicating ideas clearly with audience awareness.</p></div>
+<div class="card module-card"><a href="module23.md" class="module-number-link">23. Posters, Abstracts, and Conferences</a><p class="module-description">Sharing work with peers and professionals.</p></div>
+<div class="card module-card"><a href="module24.md" class="module-number-link">24. Career Pathways & Graduate School Prep</a><p class="module-description">Applying skills and navigating research careers.</p></div>
+<div class="card module-card"><a href="module25.md" class="module-number-link">25. Portfolio, Feedback, and Final Project</a><p class="module-description">Curating evidence of learning and capstone feedback.</p></div>
+</div>
 
 ---
 

--- a/modules/module12.md
+++ b/modules/module12.md
@@ -1,0 +1,7 @@
+---
+title: "Module 12: Big Data in Connectomics"
+layout: module
+description: "Storage, querying, and scale-aware design."
+module_number: 12
+---
+Content coming soon.

--- a/modules/module13.md
+++ b/modules/module13.md
@@ -1,0 +1,7 @@
+---
+title: "Module 13: Machine Learning in Neuroscience"
+layout: module
+description: "Intro to ML concepts and supervised/unsupervised learning."
+module_number: 13
+---
+Content coming soon.

--- a/modules/module14.md
+++ b/modules/module14.md
@@ -1,0 +1,7 @@
+---
+title: "Module 14: Computer Vision for EM"
+layout: module
+description: "From filters to deep learning for image understanding."
+module_number: 14
+---
+Content coming soon.

--- a/modules/module15.md
+++ b/modules/module15.md
@@ -1,0 +1,7 @@
+---
+title: "Module 15: LLMs for Patch Analysis"
+layout: module
+description: "Using large language models for continuity, errors, and proofing."
+module_number: 15
+---
+Content coming soon.

--- a/modules/module16.md
+++ b/modules/module16.md
@@ -1,0 +1,7 @@
+---
+title: "Module 16: Project-Based Research Planning"
+layout: module
+description: "Scoping, feasibility, and aligning skills with goals."
+module_number: 16
+---
+Content coming soon.

--- a/modules/module17.md
+++ b/modules/module17.md
@@ -1,0 +1,7 @@
+---
+title: "Module 17: Experimental Design Module 17: Experimental Design Module XX Controls Controls"
+layout: module
+description: "Establishing valid comparisons and controlling variables."
+module_number: 17
+---
+Content coming soon.

--- a/modules/module18.md
+++ b/modules/module18.md
@@ -1,0 +1,7 @@
+---
+title: "Module 18: Data Cleaning and Preprocessing"
+layout: module
+description: "Handling noise, filtering data, and reproducibility."
+module_number: 18
+---
+Content coming soon.

--- a/modules/module19.md
+++ b/modules/module19.md
@@ -1,0 +1,7 @@
+---
+title: "Module 19: Visualization for Insight"
+layout: module
+description: "Creating visualizations to explore and explain findings."
+module_number: 19
+---
+Content coming soon.

--- a/modules/module20.md
+++ b/modules/module20.md
@@ -1,0 +1,7 @@
+---
+title: "Module 20: Statistical Models and Inference"
+layout: module
+description: "Modeling techniques to interpret neural data."
+module_number: 20
+---
+Content coming soon.

--- a/modules/module21.md
+++ b/modules/module21.md
@@ -1,0 +1,7 @@
+---
+title: "Module 21: Reproducibility and FAIR Principles"
+layout: module
+description: "Ensuring research is findable, accessible, and reproducible."
+module_number: 21
+---
+Content coming soon.

--- a/modules/module22.md
+++ b/modules/module22.md
@@ -1,0 +1,7 @@
+---
+title: "Module 22: Scientific Writing Module 22: Scientific Writing Module XX Presentation Presentation"
+layout: module
+description: "Communicating ideas clearly with audience awareness."
+module_number: 22
+---
+Content coming soon.

--- a/modules/module23.md
+++ b/modules/module23.md
@@ -1,0 +1,7 @@
+---
+title: "Module 23: Posters, Abstracts, and Conferences"
+layout: module
+description: "Sharing work with peers and professionals."
+module_number: 23
+---
+Content coming soon.

--- a/modules/module24.md
+++ b/modules/module24.md
@@ -1,0 +1,7 @@
+---
+title: "Module 24: Career Pathways Module 24: Career Pathways Module XX Graduate School Prep Graduate School Prep"
+layout: module
+description: "Applying skills and navigating research careers."
+module_number: 24
+---
+Content coming soon.

--- a/modules/module25.md
+++ b/modules/module25.md
@@ -1,0 +1,7 @@
+---
+title: "Module 25: Portfolio, Feedback, and Final Project"
+layout: module
+description: "Curating evidence of learning and capstone feedback."
+module_number: 25
+---
+Content coming soon.


### PR DESCRIPTION
## Summary
- create placeholder pages for modules 12-25
- show module directory as clickable cards
- style module grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886de9fbf54832db5d0abe860ce4fdf