### PR TITLE
Fix dataset hero margin

### DIFF
--- a/datasets/index.md
+++ b/datasets/index.md
@@ -5,7 +5,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
 ---
 
 <div class="main-content">
-    <div class="hero" style="margin: -2rem -2rem 4rem -2rem; padding: 4rem 2rem;">
+    <div class="hero" style="margin: 2rem -2rem 4rem -2rem; padding: 4rem 2rem;">
         <div class="hero-content">
             <h1>Connectomics Datasets</h1>
             <p class="hero-subtitle">Learn with real scientific data from groundbreaking research</p>


### PR DESCRIPTION
## Summary
- adjust hero margin on the connectomics datasets page to add space below the top navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886e287d884832db3e7987ce8b153a2