### PR TITLE
Improve styling, remove inline CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,8 +35,8 @@
         {{ content }}
     </main>
 
-    <footer style="background: var(--synapse-black); color: var(--white); text-align: center; padding: 2rem 0; margin-top: 4rem;">
-        <div style="max-width: 1200px; margin: 0 auto; padding: 0 2rem;">
+    <footer>
+        <div class="footer-inner">
             <p>&copy; 2025 NeuroTrailblazers. Supporting the next generation of neuroscience researchers.</p>
             <p style="margin-top: 0.5rem; opacity: 0.7;">
                 Funded by {{ site.grant_info.funding_agency }} | {{ site.grant_info.program }} Program

--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -307,6 +307,11 @@ footer {
   padding: 2rem 0;
   margin-top: 4rem;
 }
+.footer-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
 
 /* Existing framework and component styles */
 .framework-grid,
@@ -398,4 +403,55 @@ footer {
   .compass-grid .workshop-focus {
     color: #ddd6fe;
   }
+}
+/* Additional page styles */
+.hero-spaced {
+  margin: -2rem -2rem 4rem -2rem;
+  padding: 4rem 2rem;
+}
+.hero-rounded {
+  border-radius: 12px;
+}
+.dataset-card-blue {
+  background: linear-gradient(135deg, #eff6ff, #dbeafe);
+  border-left: 4px solid var(--neural-blue);
+}
+.dataset-card-purple {
+  background: linear-gradient(135deg, #f3e8ff, #ede9fe);
+  border-left: 4px solid var(--cerebral-purple);
+}
+.dataset-card-cyan {
+  background: linear-gradient(135deg, #ecfeff, #cffafe);
+  border-left: 4px solid var(--axon-cyan);
+}
+.checklist-box {
+  background: var(--brain-gray);
+  padding: 2rem;
+  border-radius: 12px;
+}
+.checklist {
+  margin-top: 1rem;
+}
+.checklist label {
+  display: block;
+  margin: 0.5rem 0;
+  cursor: pointer;
+}
+.checklist input[type="checkbox"] {
+  margin-right: 0.5rem;
+  accent-color: var(--neural-blue);
+}
+.checklist label:hover {
+  background: rgba(37, 99, 235, 0.05);
+  padding: 0.25rem;
+  border-radius: 4px;
+}
+.main-content ol,
+.main-content ul {
+  color: #4b5563;
+  line-height: 1.6;
+}
+.main-content ol li,
+.main-content ul li {
+  margin: 0.25rem 0;
 }

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -90,7 +90,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
       </div>
     </div>
         <div class="cards-grid" style="margin-top: 2rem;">
-            <div class="card dataset-card" style="background: linear-gradient(135deg, #eff6ff, #dbeafe); border-left: 4px solid var(--neural-blue);">
+            <div class="card dataset-card dataset-card-blue">
                 <div class="dataset-meta">
                     <span class="dataset-year">2015</span>
                     <span class="dataset-type">Mouse Cortex</span>
@@ -111,7 +111,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
                 <a href="{{ '/datasets/kasthuri2015' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Explore Dataset</a>
             </div>
 
-            <div class="card dataset-card" style="background: linear-gradient(135deg, #f3e8ff, #ede9fe); border-left: 4px solid var(--cerebral-purple);">
+            <div class="card dataset-card dataset-card-purple">
                 <div class="dataset-meta">
                     <span class="dataset-year">2024</span>
                     <span class="dataset-type">Complete Brain</span>
@@ -132,7 +132,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
                 <a href="{{ '/datasets/flywire2024' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Explore Dataset</a>
             </div>
 
-            <div class="card dataset-card" style="background: linear-gradient(135deg, #ecfeff, #cffafe); border-left: 4px solid var(--axon-cyan);">
+            <div class="card dataset-card dataset-card-cyan">
                 <div class="dataset-meta">
                     <span class="dataset-year">2025</span>
                     <span class="dataset-type">Structure + Function</span>

--- a/index.html
+++ b/index.html
@@ -196,8 +196,8 @@ description: "A curriculum and mentorship platform for nanoscale connectomics di
         </div>
     </main>
 
-    <footer style="background: var(--synapse-black); color: var(--white); text-align: center; padding: 2rem 0; margin-top: 4rem;">
-        <div style="max-width: 1200px; margin: 0 auto; padding: 0 2rem;">
+    <footer>
+        <div class="footer-inner">
             <p>&copy; 2025 NeuroTrailblazers. Supporting the next generation of neuroscience researchers.</p>
             <p style="margin-top: 0.5rem; opacity: 0.7;">
                 Funded by {{ site.grant_info.funding_agency }} | {{ site.grant_info.program }} Program

--- a/start-here.md
+++ b/start-here.md
@@ -5,7 +5,7 @@ description: "Begin your adventure in computational neuroscience with our struct
 ---
 
 <div class="main-content">
-    <div class="hero" style="margin: -2rem -2rem 4rem -2rem; padding: 4rem 2rem;">
+    <div class="hero hero-spaced hero-rounded">
         <div class="hero-content">
             <h1>Start Your NeuroTrailblazing Journey</h1>
             <p class="hero-subtitle">Your pathway to becoming a computational neuroscience researcher</p>
@@ -137,27 +137,27 @@ description: "Begin your adventure in computational neuroscience with our struct
 
     <section class="section">
         <h2>🚀 Quick Start Checklist</h2>
-        <div style="background: var(--brain-gray); padding: 2rem; border-radius: 12px;">
+        <div class="checklist-box">
             <h3>Get Started in 5 Steps:</h3>
-            <div style="margin-top: 1rem;">
-                <label style="display: block; margin: 0.5rem 0; cursor: pointer;">
-                    <input type="checkbox" style="margin-right: 0.5rem;"> 
+            <div class="checklist">
+                <label>
+                    <input type="checkbox">
                     1. Read this Start Here guide
                 </label>
-                <label style="display: block; margin: 0.5rem 0; cursor: pointer;">
-                    <input type="checkbox" style="margin-right: 0.5rem;"> 
+                <label>
+                    <input type="checkbox">
                     2. Choose your learning path above
                 </label>
-                <label style="display: block; margin: 0.5rem 0; cursor: pointer;">
-                    <input type="checkbox" style="margin-right: 0.5rem;"> 
+                <label>
+                    <input type="checkbox">
                     3. Review the <a href="{{ '/models' | relative_url }}">educational models</a>
                 </label>
-                <label style="display: block; margin: 0.5rem 0; cursor: pointer;">
-                    <input type="checkbox" style="margin-right: 0.5rem;"> 
+                <label>
+                    <input type="checkbox">
                     4. Meet your student <a href="{{ '/archetypes/' | relative_url }}">archetype</a>
                 </label>
-                <label style="display: block; margin: 0.5rem 0; cursor: pointer;">
-                    <input type="checkbox" style="margin-right: 0.5rem;"> 
+                <label>
+                    <input type="checkbox">
                     5. Begin your first module!
                 </label>
             </div>
@@ -196,30 +196,3 @@ description: "Begin your adventure in computational neuroscience with our struct
         </div>
     </div>
 </div>
-
-<style>
-.main-content ol, .main-content ul {
-    color: #4b5563;
-    line-height: 1.6;
-}
-
-.main-content ol li, .main-content ul li {
-    margin: 0.25rem 0;
-}
-
-.hero {
-    background: linear-gradient(135deg, var(--neural-blue), var(--cerebral-purple), var(--axon-cyan));
-    color: var(--white);
-    border-radius: 12px;
-}
-
-input[type="checkbox"] {
-    accent-color: var(--neural-blue);
-}
-
-label:hover {
-    background: rgba(37, 99, 235, 0.05);
-    padding: 0.25rem;
-    border-radius: 4px;
-}
-</style>


### PR DESCRIPTION
## Summary
- move custom Start Here page styles into site CSS
- add dataset card gradient classes
- create hero spacing and checklist styles
- use new footer class and dataset card classes

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6886e1e398d8832d8c9a0735c3377a80