### PR TITLE
Refactor dataset page timeline

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -399,3 +399,38 @@ footer {
     color: #ddd6fe;
   }
 }
+
+/* Timeline styles */
+.timeline {
+  border-left: 3px solid var(--axon-cyan);
+  margin: 2rem 0;
+  padding-left: 1.5rem;
+}
+.timeline-item {
+  position: relative;
+  margin-bottom: 2rem;
+}
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -0.65rem;
+  top: 0.4rem;
+  width: 1rem;
+  height: 1rem;
+  background: var(--axon-cyan);
+  border-radius: 50%;
+}
+.timeline-year {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.dataset-facts {
+  font-size: 0.9rem;
+  color: #4b5563;
+  margin: 0.5rem 0;
+  list-style: none;
+  padding: 0;
+}
+.dataset-facts li {
+  margin-bottom: 0.25rem;
+}

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -5,222 +5,140 @@ description: "Explore curated connectomics datasets from landmark studies includ
 ---
 
 <div class="main-content">
-    <div class="hero" style="margin: -2rem -2rem 4rem -2rem; padding: 4rem 2rem;">
-        <div class="hero-content">
-            <h1>Connectomics Datasets</h1>
-            <p class="hero-subtitle">Learn with real scientific data from groundbreaking research</p>
-            <p class="hero-description">
-                Explore carefully curated datasets from landmark connectomics studies. Each dataset represents years of cutting-edge research and offers unique insights into neural circuit organization.
-            </p>
-        </div>
+  <div class="hero" style="margin: -2rem -2rem 4rem -2rem; padding: 4rem 2rem;">
+    <div class="hero-content">
+      <h1>Connectomics Datasets</h1>
+      <p class="hero-subtitle">Learn with real scientific data from groundbreaking research</p>
+      <p class="hero-description">
+        Explore carefully curated datasets from landmark connectomics studies. Each dataset represents years of cutting-edge research and offers unique insights into neural circuit organization.
+      </p>
     </div>
+  </div>
 
-    <section class="section">
-        <h2>Featured Datasets</h2>
-        <p>These datasets represent milestones in connectomics research and provide excellent learning opportunities for students at all levels.</p>
-<div class="datasets-grid">
+  <section class="section">
+    <h2>HI-MC Spotlight</h2>
     <div class="dataset-card featured spotlight">
       <div class="dataset-header">
-        <div class="dataset-icon">🏔️</div>
+        <div class="dataset-icon">🚀</div>
         <div class="dataset-meta">
-          <span class="dataset-type">Mouse Hippocampus</span>
+          <span class="dataset-type">Whole Mouse Brain</span>
           <span class="dataset-status">In Progress</span>
         </div>
       </div>
-      <h3>MouseConnects (2023-2028)</h3>
-      <p>
-        The most ambitious connectomics project ever undertaken. A complete synapse-level 
-        reconstruction of 10 mm³ of mouse hippocampal formation - 50x larger than any previous effort.
-      </p>
-      <div class="dataset-stats">
-        <div class="stat">
-          <span class="stat-value">10 mm³</span>
-          <span class="stat-label">Volume</span>
-        </div>
-        <div class="stat">
-          <span class="stat-value">10 PB</span>
-          <span class="stat-label">Raw Data</span>
-        </div>
-        <div class="stat">
-          <span class="stat-value">8×8×8 nm</span>
-          <span class="stat-label">Resolution</span>
-        </div>
-      </div>
-      <div class="dataset-tags">
-        <span class="tag">NIH BRAIN Initiative</span>
-        <span class="tag">Multi-Site</span>
-        <span class="tag">Open Science</span>
-      </div>
+      <h3><a href="/hi-mc">High-throughput Imaging for Mouse Connectomics (HI-MC)</a></h3>
+      <p>A flagship NIH CONNECTS effort to generate a scalable, synapse-resolution map of the entire mouse brain.</p>
+      <ul class="dataset-facts">
+        <li><strong>Species:</strong> Mouse</li>
+        <li><strong>Planned Volume:</strong> Whole brain</li>
+        <li><strong>Estimated Size:</strong> &gt;20 PB</li>
+      </ul>
       <div class="dataset-actions">
-        <a href="/datasets/mouseconnects" class="btn btn-primary">Explore Project</a>
+        <a href="/hi-mc" class="btn btn-primary">Project Details</a>
         <a href="/workflow" class="btn btn-secondary">View Pipeline</a>
       </div>
     </div>
+  </section>
 
-    <div class="dataset-card featured">
-      <div class="dataset-header">
-        <div class="dataset-icon">🧠</div>
-        <div class="dataset-meta">
-          <span class="dataset-type">Mammalian Cortex</span>
-          <span class="dataset-status">Active</span>
+  <section class="section">
+    <h2>Connectomics Timeline</h2>
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="timeline-year">1986</div>
+        <div class="timeline-content">
+          <h3 class="card-title">C. elegans Connectome</h3>
+          <p class="card-description">The first complete nervous system ever mapped, establishing the field of connectomics.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> C. elegans</li>
+            <li><strong>Neurons:</strong> 302</li>
+            <li><strong>Size:</strong> &lt;1 GB</li>
+          </ul>
+          <a href="{{ '/datasets/white1986' | relative_url }}" class="btn btn-secondary">Learn More</a>
         </div>
       </div>
-      <h3>Kasthuri et al. (2015)</h3>
-      <p>
-        The foundational connectome dataset that launched modern nanoscale connectomics. 
-        A dense reconstruction of mouse cortex revealing the intricate wiring of mammalian neural circuits.
-      </p>
-      <div class="dataset-stats">
-        <div class="stat">
-          <span class="stat-value">1,676</span>
-          <span class="stat-label">Synapses</span>
-        </div>
-        <div class="stat">
-          <span class="stat-value">1.4 μm³</span>
-          <span class="stat-label">Volume</span>
-        </div>
-        <div class="stat">
-          <span class="stat-value">3×3×30 nm</span>
-          <span class="stat-label">Resolution</span>
+
+      <div class="timeline-item">
+        <div class="timeline-year">2011</div>
+        <div class="timeline-content">
+          <h3 class="card-title">Bock et al. - Retinal Circuits</h3>
+          <p class="card-description">Mapping of mouse retinal circuits for visual motion detection.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Mouse</li>
+            <li><strong>Volume:</strong> ~250 μm³</li>
+            <li><strong>Size:</strong> ~2 TB</li>
+          </ul>
+          <a href="{{ '/datasets/bock2011' | relative_url }}" class="btn btn-secondary">Learn More</a>
         </div>
       </div>
-      <div class="dataset-actions">
-        <a href="/datasets/kasthuri" class="btn btn-primary">Explore Dataset</a>
-        <a href="#" class="btn btn-secondary">View Paper</a>
+
+      <div class="timeline-item">
+        <div class="timeline-year">2015</div>
+        <div class="timeline-content">
+          <h3 class="card-title">Kasthuri et al. - Visual Cortex</h3>
+          <p class="card-description">First high-resolution connectome of mammalian cortex.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Mouse</li>
+            <li><strong>Region:</strong> Visual cortex (exact area unspecified)</li>
+            <li><strong>Size:</strong> ~1 TB</li>
+          </ul>
+          <a href="{{ '/datasets/kasthuri2015' | relative_url }}" class="btn btn-primary">Explore Dataset</a>
+        </div>
+      </div>
+
+      <div class="timeline-item">
+        <div class="timeline-year">2020</div>
+        <div class="timeline-content">
+          <h3 class="card-title">Hemibrain - Fly Central Brain</h3>
+          <p class="card-description">Comprehensive mapping of the Drosophila central brain.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Drosophila</li>
+            <li><strong>Neurons:</strong> ~25,000</li>
+            <li><strong>Size:</strong> ~30 TB</li>
+          </ul>
+          <a href="{{ '/datasets/hemibrain2020' | relative_url }}" class="btn btn-secondary">Learn More</a>
+        </div>
+      </div>
+
+      <div class="timeline-item">
+        <div class="timeline-year">2024</div>
+        <div class="timeline-content">
+          <h3 class="card-title">FlyWire - Adult Fly Brain</h3>
+          <p class="card-description">First complete connectome of an adult animal brain.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Drosophila</li>
+            <li><strong>Neurons:</strong> 140,000</li>
+            <li><strong>Size:</strong> 50 TB</li>
+          </ul>
+          <a href="{{ '/datasets/flywire2024' | relative_url }}" class="btn btn-primary">Explore Dataset</a>
+        </div>
+      </div>
+
+      <div class="timeline-item">
+        <div class="timeline-year">2025</div>
+        <div class="timeline-content">
+          <h3 class="card-title">MICrONS - Mouse Visual Cortex</h3>
+          <p class="card-description">Links structural connectomics with functional recordings.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Mouse</li>
+            <li><strong>Volume:</strong> ~1 mm³</li>
+            <li><strong>Size:</strong> ~100 TB</li>
+          </ul>
+          <a href="{{ '/datasets/microns2025' | relative_url }}" class="btn btn-primary">Explore Dataset</a>
+        </div>
+      </div>
+
+      <div class="timeline-item">
+        <div class="timeline-year">2023–2028</div>
+        <div class="timeline-content">
+          <h3 class="card-title">MouseConnects</h3>
+          <p class="card-description">A complete synapse-level reconstruction of mouse hippocampal formation.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Mouse</li>
+            <li><strong>Volume:</strong> 10 mm³</li>
+            <li><strong>Size:</strong> 10 PB</li>
+          </ul>
+          <a href="/datasets/mouseconnects" class="btn btn-primary">Explore Project</a>
+        </div>
       </div>
     </div>
-        <div class="cards-grid" style="margin-top: 2rem;">
-            <div class="card dataset-card" style="background: linear-gradient(135deg, #eff6ff, #dbeafe); border-left: 4px solid var(--neural-blue);">
-                <div class="dataset-meta">
-                    <span class="dataset-year">2015</span>
-                    <span class="dataset-type">Mouse Cortex</span>
-                </div>
-                <h3 class="card-title">Kasthuri et al. - Visual Cortex</h3>
-                <p class="card-description">
-                    The first high-resolution connectome of mammalian cortex. This groundbreaking dataset revealed the complexity of cortical wiring and established many methods still used today.
-                </p>
-                <div style="margin: 1rem 0;">
-                    <strong>Key Features:</strong>
-                    <ul style="margin: 0.5rem 0 0 1rem; font-size: 0.9rem;">
-                        <li>1,676 synapses mapped</li>
-                        <li>Mouse visual cortex tissue</li>
-                        <li>Serial electron microscopy</li>
-                        <li>Detailed synapse analysis</li>
-                    </ul>
-                </div>
-                <a href="{{ '/datasets/kasthuri2015' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Explore Dataset</a>
-            </div>
-
-            <div class="card dataset-card" style="background: linear-gradient(135deg, #f3e8ff, #ede9fe); border-left: 4px solid var(--cerebral-purple);">
-                <div class="dataset-meta">
-                    <span class="dataset-year">2024</span>
-                    <span class="dataset-type">Complete Brain</span>
-                </div>
-                <h3 class="card-title">FlyWire - Adult Fly Brain</h3>
-                <p class="card-description">
-                    The first complete connectome of an adult animal brain. All 140,000 neurons and 50 million synapses mapped with unprecedented detail and accuracy.
-                </p>
-                <div style="margin: 1rem 0;">
-                    <strong>Key Features:</strong>
-                    <ul style="margin: 0.5rem 0 0 1rem; font-size: 0.9rem;">
-                        <li>Complete adult brain mapping</li>
-                        <li>Collaborative proofreading</li>
-                        <li>Cell type classification</li>
-                        <li>Interactive exploration tools</li>
-                    </ul>
-                </div>
-                <a href="{{ '/datasets/flywire2024' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Explore Dataset</a>
-            </div>
-
-            <div class="card dataset-card" style="background: linear-gradient(135deg, #ecfeff, #cffafe); border-left: 4px solid var(--axon-cyan);">
-                <div class="dataset-meta">
-                    <span class="dataset-year">2025</span>
-                    <span class="dataset-type">Structure + Function</span>
-                </div>
-                <h3 class="card-title">MICrONS - Mouse Visual Cortex</h3>
-                <p class="card-description">
-                    Revolutionary dataset combining structural connectomics with functional recordings. Links neural connectivity to actual brain activity during vision.
-                </p>
-                <div style="margin: 1rem 0;">
-                    <strong>Key Features:</strong>
-                    <ul style="margin: 0.5rem 0 0 1rem; font-size: 0.9rem;">
-                        <li>100,000+ neurons mapped</li>
-                        <li>Simultaneous functional data</li>
-                        <li>Visual stimulus responses</li>
-                        <li>AI-assisted analysis</li>
-                    </ul>
-                </div>
-                <a href="{{ '/datasets/microns2025' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Explore Dataset</a>
-            </div>
-        </div>
-    </section>
-
-    <section class="section">
-        <h2>Historical Foundations</h2>
-        <p>These classical datasets laid the groundwork for modern connectomics research and remain valuable for understanding fundamental principles.</p>
-
-        <div class="cards-grid">
-            <div class="card">
-                <div class="dataset-meta">
-                    <span class="dataset-year">1986</span>
-                    <span class="dataset-type">Complete Worm</span>
-                </div>
-                <h3 class="card-title">C. elegans Connectome</h3>
-                <p class="card-description">
-                    The first complete nervous system ever mapped. White et al.'s pioneering work on the nematode worm established the field of connectomics.
-                </p>
-                <a href="{{ '/datasets/white1986' | relative_url }}" class="btn btn-secondary" style="margin-top: 1rem;">Learn More</a>
-            </div>
-
-            <div class="card">
-                <div class="dataset-meta">
-                    <span class="dataset-year">2011</span>
-                    <span class="dataset-type">Mouse Retina</span>
-                </div>
-                <h3 class="card-title">Bock et al. - Retinal Circuits</h3>
-                <p class="card-description">
-                    Detailed mapping of mouse retinal circuits that process visual information. Revealed how retinal neurons are wired to detect motion and other features.
-                </p>
-                <a href="{{ '/datasets/bock2011' | relative_url }}" class="btn btn-secondary" style="margin-top: 1rem;">Learn More</a>
-            </div>
-
-            <div class="card">
-                <div class="dataset-meta">
-                    <span class="dataset-year">2020</span>
-                    <span class="dataset-type">Fly Brain</span>
-                </div>
-                <h3 class="card-title">Hemibrain - Fly Central Brain</h3>
-                <p class="card-description">
-                    Comprehensive mapping of the Drosophila central brain, providing insights into neural circuits for learning, memory, and behavior.
-                </p>
-                <a href="{{ '/datasets/hemibrain2020' | relative_url }}" class="btn btn-secondary" style="margin-top: 1rem;">Learn More</a>
-            </div>
-        </div>
-    </section>
-
-    <section class="section">
-        <h2>🔍 Dataset Categories</h2>
-        <p>Connectomics datasets vary in scope, species, and methodology. Understanding these categories helps you choose the right data for your learning goals.</p>
-
-        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; margin: 2rem 0;">
-            <div style="background: var(--brain-gray); padding: 1.5rem; border-radius: 12px;">
-                <h3 style="color: var(--neural-blue); margin-bottom: 1rem;">🧠 By Species</h3>
-                <ul style="color: #4b5563; margin: 0; line-height: 1.8;">
-                    <li><strong>C. elegans:</strong> Simple, complete nervous system (302 neurons)</li>
-                    <li><strong>Drosophila:</strong> Complex invertebrate brain (~140,000 neurons)</li>
-                    <li><strong>Mouse:</strong> Mammalian cortical circuits (millions of neurons)</li>
-                    <li><strong>Human:</strong> Small cortical samples (thousands of neurons)</li>
-                </ul>
-            </div>
-
-            <div style="background: var(--brain-gray); padding: 1.5rem; border-radius: 12px;">
-                <h3 style="color: var(--cerebral-purple); margin-bottom: 1rem;">🔬 By Resolution</h3>
-                <ul style="color: #4b5563; margin: 0; line-height: 1.8;">
-                    <li><strong>Synaptic:</strong> Individual synapses and connections</li>
-                    <li><strong>Cellular:</strong> Complete neuronal morphologies</li>
-                    <li><strong>Circuit:</strong> Functional neural networks</li>
-                    <li><strong>Regional:</strong> Large-scale brain organization</li>
-                </ul>
-            </div>
-
-            <div style="background: var(--
+  </section>
+</div>

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -42,6 +42,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
   <section class="section">
     <h2>Connectomics Timeline</h2>
     <div class="timeline">
+      <!-- 1986 -->
       <div class="timeline-item">
         <div class="timeline-year">1986</div>
         <div class="timeline-content">
@@ -56,6 +57,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
         </div>
       </div>
 
+      <!-- 2011 -->
       <div class="timeline-item">
         <div class="timeline-year">2011</div>
         <div class="timeline-content">
@@ -70,6 +72,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
         </div>
       </div>
 
+      <!-- 2015 -->
       <div class="timeline-item">
         <div class="timeline-year">2015</div>
         <div class="timeline-content">
@@ -84,6 +87,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
         </div>
       </div>
 
+      <!-- 2020 -->
       <div class="timeline-item">
         <div class="timeline-year">2020</div>
         <div class="timeline-content">
@@ -98,6 +102,22 @@ description: "Explore curated connectomics datasets from landmark studies includ
         </div>
       </div>
 
+      <!-- 2023-2028 -->
+      <div class="timeline-item">
+        <div class="timeline-year">2023–2028</div>
+        <div class="timeline-content">
+          <h3 class="card-title">MouseConnects</h3>
+          <p class="card-description">A complete synapse-level reconstruction of mouse hippocampal formation.</p>
+          <ul class="dataset-facts">
+            <li><strong>Species:</strong> Mouse</li>
+            <li><strong>Volume:</strong> 10 mm³</li>
+            <li><strong>Size:</strong> 10 PB</li>
+          </ul>
+          <a href="/datasets/mouseconnects" class="btn btn-primary">Explore Project</a>
+        </div>
+      </div>
+
+      <!-- 2024 -->
       <div class="timeline-item">
         <div class="timeline-year">2024</div>
         <div class="timeline-content">
@@ -112,6 +132,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
         </div>
       </div>
 
+      <!-- 2025 -->
       <div class="timeline-item">
         <div class="timeline-year">2025</div>
         <div class="timeline-content">
@@ -125,19 +146,32 @@ description: "Explore curated connectomics datasets from landmark studies includ
           <a href="{{ '/datasets/microns2025' | relative_url }}" class="btn btn-primary">Explore Dataset</a>
         </div>
       </div>
+    </div>
+  </section>
 
-      <div class="timeline-item">
-        <div class="timeline-year">2023–2028</div>
-        <div class="timeline-content">
-          <h3 class="card-title">MouseConnects</h3>
-          <p class="card-description">A complete synapse-level reconstruction of mouse hippocampal formation.</p>
-          <ul class="dataset-facts">
-            <li><strong>Species:</strong> Mouse</li>
-            <li><strong>Volume:</strong> 10 mm³</li>
-            <li><strong>Size:</strong> 10 PB</li>
-          </ul>
-          <a href="/datasets/mouseconnects" class="btn btn-primary">Explore Project</a>
-        </div>
+  <section class="section">
+    <h2>🔍 Dataset Categories</h2>
+    <p>Connectomics datasets vary in scope, species, and methodology. Understanding these categories helps you choose the right data for your learning goals.</p>
+
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 2rem; margin: 2rem 0;">
+      <div style="background: var(--brain-gray); padding: 1.5rem; border-radius: 12px;">
+        <h3 style="color: var(--neural-blue); margin-bottom: 1rem;">🤓 By Species</h3>
+        <ul style="color: #4b5563; margin: 0; line-height: 1.8;">
+          <li><strong>C. elegans:</strong> Simple, complete nervous system (302 neurons)</li>
+          <li><strong>Drosophila:</strong> Complex invertebrate brain (~140,000 neurons)</li>
+          <li><strong>Mouse:</strong> Mammalian cortical circuits (millions of neurons)</li>
+          <li><strong>Human:</strong> Small cortical samples (thousands of neurons)</li>
+        </ul>
+      </div>
+
+      <div style="background: var(--brain-gray); padding: 1.5rem; border-radius: 12px;">
+        <h3 style="color: var(--cerebral-purple); margin-bottom: 1rem;">🔬 By Resolution</h3>
+        <ul style="color: #4b5563; margin: 0; line-height: 1.8;">
+          <li><strong>Synaptic:</strong> Individual synapses and connections</li>
+          <li><strong>Cellular:</strong> Complete neuronal morphologies</li>
+          <li><strong>Circuit:</strong> Functional neural networks</li>
+          <li><strong>Regional:</strong> Large-scale brain organization</li>
+        </ul>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- restructure datasets index to a timeline view
- highlight HI-MC at the top
- add dataset facts for species, volume, and size
- add CSS for new timeline component

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6886e22ffae0832da1441363b0442d0a