### PR TITLE
Improve module matrix layout

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -256,6 +256,42 @@ body {
   color: #4b5563;
   margin-top: 0.25rem;
 }
+
+/* Merit matrix styles */
+.merit-matrix {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  margin-bottom: 2rem;
+}
+
+.merit-card {
+  background: var(--white);
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+  padding: 1rem;
+}
+
+.module-subcards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.module-subcard {
+  background: var(--brain-gray);
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  text-decoration: none;
+  color: var(--neural-blue);
+  font-weight: 600;
+}
+
+.module-subcard:hover {
+  text-decoration: underline;
+}
 .workflow-preview {
   display: flex;
   align-items: center;

--- a/modules/index.md
+++ b/modules/index.md
@@ -10,87 +10,213 @@ permalink: /modules/
 
 This curriculum includes 25 structured modules aligned with the MERIT model (Mentoring Exceptional Researchers to Innovate and Thrive) and the COMPASS framework (Charting Opportunity, Mastery, Purpose, Agency, Skills, and Self). Each module is tagged by its place in the research pipeline and grounded in CCR (Center for Curriculum Redesign) learning dimensions: Knowledge, Skills, Character, Meta-Learning, and Motivation.
 
-## 📚 Module Directory
+## 🧠 MERIT × CCR Curriculum Matrix
 
-### Module List with Descriptions
+<div class="merit-matrix">
+  <div class="merit-card">
+    <h3>Foundations</h3>
+    <p><strong>Knowledge</strong></p>
+    <div class="module-subcards">
+      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+      <a href="module03.md" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
+      <a href="module04.md" class="module-subcard">04. Neuroanatomy for Connectomics</a>
+    </div>
+    <p><strong>Skills</strong></p>
+    <div class="module-subcards">
+      <a href="module03.md" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
+      <a href="module05.md" class="module-subcard">05. Electron Microscopy and Image Basics</a>
+    </div>
+    <p><strong>Character</strong></p>
+    <div class="module-subcards">
+      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+    </div>
+    <p><strong>Meta-Learning</strong></p>
+    <div class="module-subcards">
+      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+      <a href="module03.md" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
+    </div>
+    <p><strong>Motivation</strong></p>
+    <div class="module-subcards">
+      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+    </div>
+  </div>
 
-<div class="modules-grid">
-<div class="card module-card"><a href="module01.md" class="module-number-link">01. Scientific Curiosity & Motivation</a><p class="module-description">Orientation to scientific thinking, growth mindset, and curiosity-driven inquiry.</p></div>
-<div class="card module-card"><a href="module02.md" class="module-number-link">02. Research Foundations & the Hidden Curriculum</a><p class="module-description">Unwritten norms in science, research roles, and building confidence.</p></div>
-<div class="card module-card"><a href="module03.md" class="module-number-link">03. Python and Jupyter for Neuroscience</a><p class="module-description">Intro to coding in Python, Jupyter notebooks, and tools for analysis.</p></div>
-<div class="card module-card"><a href="module04.md" class="module-number-link">04. Neuroanatomy for Connectomics</a><p class="module-description">Understanding neural structure at micro- and macro-scale.</p></div>
-<div class="card module-card"><a href="module05.md" class="module-number-link">05. Electron Microscopy and Image Basics</a><p class="module-description">EM imaging principles, file formats, and interpretation.</p></div>
-<div class="card module-card"><a href="module06.md" class="module-number-link">06. Segmentation 101</a><p class="module-description">Understanding segmentation, labels, and sources of error.</p></div>
-<div class="card module-card"><a href="module07.md" class="module-number-link">07. Proofreading and Quality Control</a><p class="module-description">Identifying merge/split errors and assessing segmentation quality.</p></div>
-<div class="card module-card"><a href="module08.md" class="module-number-link">08. Hypothesis Testing in Connectomics</a><p class="module-description">Defining and testing hypotheses using statistical tools.</p></div>
-<div class="card module-card"><a href="module09.md" class="module-number-link">09. Neuron Morphology & Skeletonization</a><p class="module-description">Exploring cell shape, skeletons, and biofeatures.</p></div>
-<div class="card module-card"><a href="module10.md" class="module-number-link">10. Network Science & Graph Representation</a><p class="module-description">Introduction to graphs, adjacency, and connectome structure.</p></div>
-<div class="card module-card"><a href="module11.md" class="module-number-link">11. Synapses and Circuit Logic</a><p class="module-description">Mapping synaptic connectivity and interpreting motifs.</p></div>
-<div class="card module-card"><a href="module12.md" class="module-number-link">12. Big Data in Connectomics</a><p class="module-description">Storage, querying, and scale-aware design.</p></div>
-<div class="card module-card"><a href="module13.md" class="module-number-link">13. Machine Learning in Neuroscience</a><p class="module-description">Intro to ML concepts and supervised/unsupervised learning.</p></div>
-<div class="card module-card"><a href="module14.md" class="module-number-link">14. Computer Vision for EM</a><p class="module-description">From filters to deep learning for image understanding.</p></div>
-<div class="card module-card"><a href="module15.md" class="module-number-link">15. LLMs for Patch Analysis</a><p class="module-description">Using large language models for continuity, errors, and proofing.</p></div>
-<div class="card module-card"><a href="module16.md" class="module-number-link">16. Project-Based Research Planning</a><p class="module-description">Scoping, feasibility, and aligning skills with goals.</p></div>
-<div class="card module-card"><a href="module17.md" class="module-number-link">17. Experimental Design & Controls</a><p class="module-description">Establishing valid comparisons and controlling variables.</p></div>
-<div class="card module-card"><a href="module18.md" class="module-number-link">18. Data Cleaning and Preprocessing</a><p class="module-description">Handling noise, filtering data, and reproducibility.</p></div>
-<div class="card module-card"><a href="module19.md" class="module-number-link">19. Visualization for Insight</a><p class="module-description">Creating visualizations to explore and explain findings.</p></div>
-<div class="card module-card"><a href="module20.md" class="module-number-link">20. Statistical Models and Inference</a><p class="module-description">Modeling techniques to interpret neural data.</p></div>
-<div class="card module-card"><a href="module21.md" class="module-number-link">21. Reproducibility and FAIR Principles</a><p class="module-description">Ensuring research is findable, accessible, and reproducible.</p></div>
-<div class="card module-card"><a href="module22.md" class="module-number-link">22. Scientific Writing & Presentation</a><p class="module-description">Communicating ideas clearly with audience awareness.</p></div>
-<div class="card module-card"><a href="module23.md" class="module-number-link">23. Posters, Abstracts, and Conferences</a><p class="module-description">Sharing work with peers and professionals.</p></div>
-<div class="card module-card"><a href="module24.md" class="module-number-link">24. Career Pathways & Graduate School Prep</a><p class="module-description">Applying skills and navigating research careers.</p></div>
-<div class="card module-card"><a href="module25.md" class="module-number-link">25. Portfolio, Feedback, and Final Project</a><p class="module-description">Curating evidence of learning and capstone feedback.</p></div>
+  <div class="merit-card">
+    <h3>Question</h3>
+    <p><strong>Knowledge</strong></p>
+    <div class="module-subcards">
+      <a href="module04.md" class="module-subcard">04. Neuroanatomy for Connectomics</a>
+      <a href="module05.md" class="module-subcard">05. Electron Microscopy and Image Basics</a>
+      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+    </div>
+    <p><strong>Skills</strong></p>
+    <div class="module-subcards">
+      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+      <a href="module07.md" class="module-subcard">07. Proofreading and Quality Control</a>
+    </div>
+    <p><strong>Character</strong></p>
+    <div class="module-subcards">
+      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+      <a href="module07.md" class="module-subcard">07. Proofreading and Quality Control</a>
+    </div>
+    <p><strong>Meta-Learning</strong></p>
+    <div class="module-subcards">
+      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+      <a href="module07.md" class="module-subcard">07. Proofreading and Quality Control</a>
+      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+    </div>
+    <p><strong>Motivation</strong></p>
+    <div class="module-subcards">
+      <a href="module04.md" class="module-subcard">04. Neuroanatomy for Connectomics</a>
+      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+    </div>
+  </div>
+
+  <div class="merit-card">
+    <h3>Experiment</h3>
+    <p><strong>Knowledge</strong></p>
+    <div class="module-subcards">
+      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module09.md" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
+      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+      <a href="module11.md" class="module-subcard">11. Synapses and Circuit Logic</a>
+    </div>
+    <p><strong>Skills</strong></p>
+    <div class="module-subcards">
+      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module09.md" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
+      <a href="module11.md" class="module-subcard">11. Synapses and Circuit Logic</a>
+    </div>
+    <p><strong>Character</strong></p>
+    <div class="module-subcards">
+      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+    </div>
+    <p><strong>Meta-Learning</strong></p>
+    <div class="module-subcards">
+      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module09.md" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
+      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+    </div>
+    <p><strong>Motivation</strong></p>
+    <div class="module-subcards">
+      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+    </div>
+  </div>
+
+  <div class="merit-card">
+    <h3>Analysis</h3>
+    <p><strong>Knowledge</strong></p>
+    <div class="module-subcards">
+      <a href="module12.md" class="module-subcard">12. Big Data in Connectomics</a>
+      <a href="module13.md" class="module-subcard">13. Machine Learning in Neuroscience</a>
+      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module20.md" class="module-subcard">20. Statistical Models and Inference</a>
+    </div>
+    <p><strong>Skills</strong></p>
+    <div class="module-subcards">
+      <a href="module13.md" class="module-subcard">13. Machine Learning in Neuroscience</a>
+      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module18.md" class="module-subcard">18. Data Cleaning and Preprocessing</a>
+      <a href="module19.md" class="module-subcard">19. Visualization for Insight</a>
+    </div>
+    <p><strong>Character</strong></p>
+    <div class="module-subcards">
+      <a href="module12.md" class="module-subcard">12. Big Data in Connectomics</a>
+      <a href="module13.md" class="module-subcard">13. Machine Learning in Neuroscience</a>
+      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
+    </div>
+    <p><strong>Meta-Learning</strong></p>
+    <div class="module-subcards">
+      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module18.md" class="module-subcard">18. Data Cleaning and Preprocessing</a>
+      <a href="module19.md" class="module-subcard">19. Visualization for Insight</a>
+      <a href="module20.md" class="module-subcard">20. Statistical Models and Inference</a>
+    </div>
+    <p><strong>Motivation</strong></p>
+    <div class="module-subcards">
+      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
+    </div>
+  </div>
+
+  <div class="merit-card">
+    <h3>Dissemination</h3>
+    <p><strong>Knowledge</strong></p>
+    <div class="module-subcards">
+      <a href="module21.md" class="module-subcard">21. Reproducibility and FAIR Principles</a>
+      <a href="module22.md" class="module-subcard">22. Scientific Writing & Presentation</a>
+      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+    </div>
+    <p><strong>Skills</strong></p>
+    <div class="module-subcards">
+      <a href="module22.md" class="module-subcard">22. Scientific Writing & Presentation</a>
+      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+    </div>
+    <p><strong>Character</strong></p>
+    <div class="module-subcards">
+      <a href="module21.md" class="module-subcard">21. Reproducibility and FAIR Principles</a>
+      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+    </div>
+    <p><strong>Meta-Learning</strong></p>
+    <div class="module-subcards">
+      <a href="module22.md" class="module-subcard">22. Scientific Writing & Presentation</a>
+      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+    </div>
+    <p><strong>Motivation</strong></p>
+    <div class="module-subcards">
+      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+    </div>
+  </div>
 </div>
 
 ---
 
-## 🧠 MERIT × CCR Curriculum Grid
+## 📚 Full Module Index
 
-<div class="framework-grid">
-  <div class="merit-stage">
-    <h3>Foundations</h3>
-    <p><strong>Knowledge:</strong> 01, 02, 03, 04</p>
-    <p><strong>Skills:</strong> 03, 05</p>
-    <p><strong>Character:</strong> 01, 02</p>
-    <p><strong>Meta-Learning:</strong> 01, 02, 03</p>
-    <p><strong>Motivation:</strong> 01, 02</p>
-  </div>
-  <div class="merit-stage">
-    <h3>Question</h3>
-    <p><strong>Knowledge:</strong> 04, 05, 06</p>
-    <p><strong>Skills:</strong> 06, 07</p>
-    <p><strong>Character:</strong> 06, 07</p>
-    <p><strong>Meta-Learning:</strong> 06, 07, 08</p>
-    <p><strong>Motivation:</strong> 04, 06</p>
-  </div>
-  <div class="merit-stage">
-    <h3>Experiment</h3>
-    <p><strong>Knowledge:</strong> 08, 09, 10, 11</p>
-    <p><strong>Skills:</strong> 08, 09, 11</p>
-    <p><strong>Character:</strong> 08, 10</p>
-    <p><strong>Meta-Learning:</strong> 08, 09, 10</p>
-    <p><strong>Motivation:</strong> 08, 10</p>
-  </div>
-  <div class="merit-stage">
-    <h3>Analysis</h3>
-    <p><strong>Knowledge:</strong> 12, 13, 14, 15, 20</p>
-    <p><strong>Skills:</strong> 13, 14, 15, 18, 19</p>
-    <p><strong>Character:</strong> 12, 13, 14</p>
-    <p><strong>Meta-Learning:</strong> 15, 18, 19, 20</p>
-    <p><strong>Motivation:</strong> 14, 15</p>
-  </div>
-  <div class="merit-stage">
-    <h3>Dissemination</h3>
-    <p><strong>Knowledge:</strong> 21, 22, 23, 24, 25</p>
-    <p><strong>Skills:</strong> 22, 23, 25</p>
-    <p><strong>Character:</strong> 21, 23, 24</p>
-    <p><strong>Meta-Learning:</strong> 22, 23, 24, 25</p>
-    <p><strong>Motivation:</strong> 24, 25</p>
-  </div>
+<div class="modules-grid">
+  <div class="card module-card"><a href="module01.md" class="module-number-link">01. Scientific Curiosity & Motivation</a><p class="module-description">Orientation to scientific thinking, growth mindset, and curiosity-driven inquiry.</p></div>
+  <div class="card module-card"><a href="module02.md" class="module-number-link">02. Research Foundations & the Hidden Curriculum</a><p class="module-description">Unwritten norms in science, research roles, and building confidence.</p></div>
+  <div class="card module-card"><a href="module03.md" class="module-number-link">03. Python and Jupyter for Neuroscience</a><p class="module-description">Intro to coding in Python, Jupyter notebooks, and tools for analysis.</p></div>
+  <div class="card module-card"><a href="module04.md" class="module-number-link">04. Neuroanatomy for Connectomics</a><p class="module-description">Understanding neural structure at micro- and macro-scale.</p></div>
+  <div class="card module-card"><a href="module05.md" class="module-number-link">05. Electron Microscopy and Image Basics</a><p class="module-description">EM imaging principles, file formats, and interpretation.</p></div>
+  <div class="card module-card"><a href="module06.md" class="module-number-link">06. Segmentation 101</a><p class="module-description">Understanding segmentation, labels, and sources of error.</p></div>
+  <div class="card module-card"><a href="module07.md" class="module-number-link">07. Proofreading and Quality Control</a><p class="module-description">Identifying merge/split errors and assessing segmentation quality.</p></div>
+  <div class="card module-card"><a href="module08.md" class="module-number-link">08. Hypothesis Testing in Connectomics</a><p class="module-description">Defining and testing hypotheses using statistical tools.</p></div>
+  <div class="card module-card"><a href="module09.md" class="module-number-link">09. Neuron Morphology & Skeletonization</a><p class="module-description">Exploring cell shape, skeletons, and biofeatures.</p></div>
+  <div class="card module-card"><a href="module10.md" class="module-number-link">10. Network Science & Graph Representation</a><p class="module-description">Introduction to graphs, adjacency, and connectome structure.</p></div>
+  <div class="card module-card"><a href="module11.md" class="module-number-link">11. Synapses and Circuit Logic</a><p class="module-description">Mapping synaptic connectivity and interpreting motifs.</p></div>
+  <div class="card module-card"><a href="module12.md" class="module-number-link">12. Big Data in Connectomics</a><p class="module-description">Storage, querying, and scale-aware design.</p></div>
+  <div class="card module-card"><a href="module13.md" class="module-number-link">13. Machine Learning in Neuroscience</a><p class="module-description">Intro to ML concepts and supervised/unsupervised learning.</p></div>
+  <div class="card module-card"><a href="module14.md" class="module-number-link">14. Computer Vision for EM</a><p class="module-description">From filters to deep learning for image understanding.</p></div>
+  <div class="card module-card"><a href="module15.md" class="module-number-link">15. LLMs for Patch Analysis</a><p class="module-description">Using large language models for continuity, errors, and proofing.</p></div>
+  <div class="card module-card"><a href="module16.md" class="module-number-link">16. Project-Based Research Planning</a><p class="module-description">Scoping, feasibility, and aligning skills with goals.</p></div>
+  <div class="card module-card"><a href="module17.md" class="module-number-link">17. Experimental Design & Controls</a><p class="module-description">Establishing valid comparisons and controlling variables.</p></div>
+  <div class="card module-card"><a href="module18.md" class="module-number-link">18. Data Cleaning and Preprocessing</a><p class="module-description">Handling noise, filtering data, and reproducibility.</p></div>
+  <div class="card module-card"><a href="module19.md" class="module-number-link">19. Visualization for Insight</a><p class="module-description">Creating visualizations to explore and explain findings.</p></div>
+  <div class="card module-card"><a href="module20.md" class="module-number-link">20. Statistical Models and Inference</a><p class="module-description">Modeling techniques to interpret neural data.</p></div>
+  <div class="card module-card"><a href="module21.md" class="module-number-link">21. Reproducibility and FAIR Principles</a><p class="module-description">Ensuring research is findable, accessible, and reproducible.</p></div>
+  <div class="card module-card"><a href="module22.md" class="module-number-link">22. Scientific Writing & Presentation</a><p class="module-description">Communicating ideas clearly with audience awareness.</p></div>
+  <div class="card module-card"><a href="module23.md" class="module-number-link">23. Posters, Abstracts, and Conferences</a><p class="module-description">Sharing work with peers and professionals.</p></div>
+  <div class="card module-card"><a href="module24.md" class="module-number-link">24. Career Pathways & Graduate School Prep</a><p class="module-description">Applying skills and navigating research careers.</p></div>
+  <div class="card module-card"><a href="module25.md" class="module-number-link">25. Portfolio, Feedback, and Final Project</a><p class="module-description">Curating evidence of learning and capstone feedback.</p></div>
 </div>
-
-<p><em>Each card summarizes module numbers aligned with the MERIT stage and CCR dimension.</em></p>
 
 ---
 
 Need help deciding where to start? Try **[Module 01](module01.md)** or visit our [About](/about/) page to learn more about the MERIT and COMPASS frameworks.
+


### PR DESCRIPTION
## Summary
- restructure the modules page to present MERIT × CCR matrix as cards with clickable module subcards
- add full module index at bottom of page
- style merit matrix with new CSS rules

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6886e2dde910832db68b141adcc3c31f