### PR TITLE
Fix modules footer link

### DIFF
--- a/modules/index.md
+++ b/modules/index.md
@@ -218,5 +218,5 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
 
 ---
 
-Need help deciding where to start? Try **[Module 01](module01.md)** or visit our [About](/about/) page to learn more about the MERIT and COMPASS frameworks.
+Need help deciding where to start? Try **[Module 01](module01.md)** or visit our [Models](/models/) page to learn more about the MERIT and COMPASS frameworks.
 


### PR DESCRIPTION
## Summary
- update footer link on modules page to reference the Models page
- no `about` page was present to remove

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886e770b8fc832d90110579995009a6