### PR TITLE
Add container style for consistent page padding

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -30,6 +30,12 @@ body {
   justify-content: space-between;
 }
 
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
 .logo {
   font-size: 1.5rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add `.container` style so workflow page text isn't flush against the edge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886efc3f18c832d899d31e1cb0dd8dd