### PR TITLE
Fix navigation references to avatars and link dataset access

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ collections:
   modules:
     output: true
     permalink: /:collection/:name/
-  archetypes:
+  avatars:
     output: true
     permalink: /:collection/:name/
   datasets:
@@ -33,7 +33,7 @@ defaults:
       layout: "module"
   - scope:
       path: ""
-      type: "archetypes"
+      type: "avatars"
     values:
       layout: "archetype"
   - scope:
@@ -74,8 +74,8 @@ navigation:
         url: "/modules/"
   - title: "Datasets"
     url: "/datasets/"
-  - title: "Archetypes"
-    url: "/archetypes/"
+  - title: "Avatars"
+    url: "/avatars/"
 
 # Grant and program information
 grant_info:

--- a/datasets/access.md
+++ b/datasets/access.md
@@ -1,5 +1,11 @@
 # Getting Started with EM Connectomics Datasets
 
+---
+layout: dataset
+title: "Accessing Public EM Datasets"
+description: "Resources and notebooks for downloading and exploring connectomics data."
+---
+
 A guide to resources and example notebooks for accessing major public Electron Microscopy (EM) connectomics datasets.
 
 ---

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -177,4 +177,10 @@ description: "Explore curated connectomics datasets from landmark studies includ
       </div>
     </div>
   </section>
+
+  <section class="section" style="text-align: center;">
+    <h2>📂 Accessing These Datasets</h2>
+    <p>Follow our step-by-step guide to download data from public repositories.</p>
+    <a href="{{ '/datasets/access' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Dataset Access Guide</a>
+  </section>
 </div>

--- a/hi-mc.md
+++ b/hi-mc.md
@@ -72,5 +72,5 @@ Students trained through NeuroTrailblazers are not just observers — they are c
 
 To get started contributing:
 - Explore the [Workflow](/workflow)
-- Meet the [Archetypes](/archetypes/)
+- Meet the [Avatars](/avatars/)
 - Try a [Module](/modules/module01/)

--- a/index.html
+++ b/index.html
@@ -172,11 +172,11 @@ description: "A curriculum and mentorship platform for nanoscale connectomics di
                     </div>
                     <div class="card">
                         <div class="card-icon">👤</div>
-                        <h3 class="card-title">Student Archetypes</h3>
+                        <h3 class="card-title">Student Avatars</h3>
                         <p class="card-description">
                             Meet Julian, Layla, and Elias - representative student profiles to guide your learning journey.
                         </p>
-                        <a href="{{ '/archetypes/' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Meet Students</a>
+                        <a href="{{ '/avatars/' | relative_url }}" class="btn btn-primary" style="margin-top: 1rem;">Meet Students</a>
                     </div>
                 </div>
             </section>

--- a/start-here.md
+++ b/start-here.md
@@ -77,7 +77,7 @@ description: "Begin your adventure in computational neuroscience with our struct
             </div>
         </div>
 
-        <h3>Student Archetypes</h3>
+        <h3>Student Avatars</h3>
         <p>Meet our representative students to see yourself in their journeys:</p>
         <div class="cards-grid" style="margin-top: 1rem;">
             <div class="card" style="text-align: center;">
@@ -154,7 +154,7 @@ description: "Begin your adventure in computational neuroscience with our struct
                 </label>
                 <label>
                     <input type="checkbox">
-                    4. Meet your student <a href="{{ '/archetypes/' | relative_url }}">archetype</a>
+                    4. Meet your student <a href="{{ '/avatars/' | relative_url }}">avatar</a>
                 </label>
                 <label>
                     <input type="checkbox">

--- a/tools/neurotrailblazers-chat-logic/persona-composer-guide.txt
+++ b/tools/neurotrailblazers-chat-logic/persona-composer-guide.txt
@@ -1,6 +1,6 @@
 NeuroTrailblazers Persona Composer
 
-To generate a new archetype:
+To generate a new avatar:
 
 1. Choose MERIT focus (e.g., Motivation, Skills, Character)
 2. Select career stage (e.g., undergrad, grad, postdoc, industry)

--- a/workflow.md
+++ b/workflow.md
@@ -358,9 +358,9 @@ description: "Learn the complete pipeline for nanoscale connectomics research, f
       </div>
       
       <div class="cta-card">
-        <h3>👥 Find Your Archetype</h3>
+        <h3>👥 Find Your Avatar</h3>
         <p>See how students like you navigate connectomics research</p>
-        <a href="/archetypes/" class="btn btn-secondary">Student Stories</a>
+        <a href="/avatars/" class="btn btn-secondary">Student Stories</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- link dataset access guide from dataset index
- add front matter to the access dataset page
- rename archetypes navigation to avatars
- update all internal links and headings
- tweak persona composer guide wording

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6886f6283820832d9da01ac5a439865a