### PR TITLE
Fix dataset links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,7 +62,7 @@ navigation:
   - title: "Models"
     url: "/models"
   - title: "Workflow"
-    url: "/workflow"
+    url: "/datasets/workflow"
   - title: "Modules"
     url: "/modules/"
     dropdown:

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -25,7 +25,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
           <span class="dataset-status">In Progress (2023-2028)</span>
         </div>
       </div>
-      <h3><a href="/mouseconnects">MouseConnects: High-throughput Imaging for Mouse Connectomics (HI-MC)</a></h3>
+      <h3><a href="{{ '/datasets/mouseconnects' | relative_url }}">MouseConnects: High-throughput Imaging for Mouse Connectomics (HI-MC)</a></h3>
       <p>A flagship $40M NIH BRAIN CONNECTS effort to reconstruct <strong>10&nbsp;mm³</strong> of mouse hippocampal formation at nanometer resolution&mdash;the most ambitious connectomics project ever undertaken.</p>
       <ul class="dataset-facts">
         <li><strong>Species:</strong> Mouse (C57BL/6)</li>
@@ -34,8 +34,8 @@ description: "Explore curated connectomics datasets from landmark studies includ
         <li><strong>Resolution:</strong> 8 nm isotropic</li>
       </ul>
       <div class="dataset-actions">
-        <a href="/mouseconnects" class="btn btn-primary">Project Details</a>
-        <a href="/workflow" class="btn btn-secondary">View Pipeline</a>
+        <a href="{{ '/datasets/mouseconnects' | relative_url }}" class="btn btn-primary">Project Details</a>
+        <a href="{{ '/datasets/workflow' | relative_url }}" class="btn btn-secondary">View Pipeline</a>
       </div>
     </div>
   </section>

--- a/hi-mc.md
+++ b/hi-mc.md
@@ -71,6 +71,6 @@ Students trained through NeuroTrailblazers are not just observers — they are c
 ## 🚀 Learn More
 
 To get started contributing:
-- Explore the [Workflow](/workflow)
+- Explore the [Workflow]({{ '/datasets/workflow' | relative_url }})
 - Meet the [Avatars](/avatars/)
 - Try a [Module](/modules/module01/)

--- a/start-here.md
+++ b/start-here.md
@@ -192,7 +192,7 @@ description: "Begin your adventure in computational neuroscience with our struct
         <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-top: 2rem;">
             <a href="{{ '/modules/' | relative_url }}" class="btn btn-primary">View All Modules</a>
             <a href="{{ '/datasets/' | relative_url }}" class="btn btn-secondary">Explore Datasets</a>
-            <a href="{{ '/workflow' | relative_url }}" class="btn btn-secondary">See Our Workflow</a>
+            <a href="{{ '/datasets/workflow' | relative_url }}" class="btn btn-secondary">See Our Workflow</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- fix dataset card links to use `relative_url`
- update navigation and pages to point at datasets workflow page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68879cedcdd0832da3cb46f1f06fc589