### PR TITLE
Fix broken module links

### DIFF
--- a/modules/index.md
+++ b/modules/index.md
@@ -17,31 +17,31 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <h3>Foundations</h3>
     <p><strong>Knowledge</strong></p>
     <div class="module-subcards">
-      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
-      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
-      <a href="module03.md" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
-      <a href="module04.md" class="module-subcard">04. Neuroanatomy for Connectomics</a>
+      <a href="module01" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+      <a href="module03" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
+      <a href="module04" class="module-subcard">04. Neuroanatomy for Connectomics</a>
     </div>
     <p><strong>Skills</strong></p>
     <div class="module-subcards">
-      <a href="module03.md" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
-      <a href="module05.md" class="module-subcard">05. Electron Microscopy and Image Basics</a>
+      <a href="module03" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
+      <a href="module05" class="module-subcard">05. Electron Microscopy and Image Basics</a>
     </div>
     <p><strong>Character</strong></p>
     <div class="module-subcards">
-      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
-      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+      <a href="module01" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
     </div>
     <p><strong>Meta-Learning</strong></p>
     <div class="module-subcards">
-      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
-      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
-      <a href="module03.md" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
+      <a href="module01" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+      <a href="module03" class="module-subcard">03. Python and Jupyter for Neuroscience</a>
     </div>
     <p><strong>Motivation</strong></p>
     <div class="module-subcards">
-      <a href="module01.md" class="module-subcard">01. Scientific Curiosity & Motivation</a>
-      <a href="module02.md" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
+      <a href="module01" class="module-subcard">01. Scientific Curiosity & Motivation</a>
+      <a href="module02" class="module-subcard">02. Research Foundations & the Hidden Curriculum</a>
     </div>
   </div>
 
@@ -49,30 +49,30 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <h3>Question</h3>
     <p><strong>Knowledge</strong></p>
     <div class="module-subcards">
-      <a href="module04.md" class="module-subcard">04. Neuroanatomy for Connectomics</a>
-      <a href="module05.md" class="module-subcard">05. Electron Microscopy and Image Basics</a>
-      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+      <a href="module04" class="module-subcard">04. Neuroanatomy for Connectomics</a>
+      <a href="module05" class="module-subcard">05. Electron Microscopy and Image Basics</a>
+      <a href="module06" class="module-subcard">06. Segmentation 101</a>
     </div>
     <p><strong>Skills</strong></p>
     <div class="module-subcards">
-      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
-      <a href="module07.md" class="module-subcard">07. Proofreading and Quality Control</a>
+      <a href="module06" class="module-subcard">06. Segmentation 101</a>
+      <a href="module07" class="module-subcard">07. Proofreading and Quality Control</a>
     </div>
     <p><strong>Character</strong></p>
     <div class="module-subcards">
-      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
-      <a href="module07.md" class="module-subcard">07. Proofreading and Quality Control</a>
+      <a href="module06" class="module-subcard">06. Segmentation 101</a>
+      <a href="module07" class="module-subcard">07. Proofreading and Quality Control</a>
     </div>
     <p><strong>Meta-Learning</strong></p>
     <div class="module-subcards">
-      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
-      <a href="module07.md" class="module-subcard">07. Proofreading and Quality Control</a>
-      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module06" class="module-subcard">06. Segmentation 101</a>
+      <a href="module07" class="module-subcard">07. Proofreading and Quality Control</a>
+      <a href="module08" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
     </div>
     <p><strong>Motivation</strong></p>
     <div class="module-subcards">
-      <a href="module04.md" class="module-subcard">04. Neuroanatomy for Connectomics</a>
-      <a href="module06.md" class="module-subcard">06. Segmentation 101</a>
+      <a href="module04" class="module-subcard">04. Neuroanatomy for Connectomics</a>
+      <a href="module06" class="module-subcard">06. Segmentation 101</a>
     </div>
   </div>
 
@@ -80,32 +80,32 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <h3>Experiment</h3>
     <p><strong>Knowledge</strong></p>
     <div class="module-subcards">
-      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
-      <a href="module09.md" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
-      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
-      <a href="module11.md" class="module-subcard">11. Synapses and Circuit Logic</a>
+      <a href="module08" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module09" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
+      <a href="module10" class="module-subcard">10. Network Science & Graph Representation</a>
+      <a href="module11" class="module-subcard">11. Synapses and Circuit Logic</a>
     </div>
     <p><strong>Skills</strong></p>
     <div class="module-subcards">
-      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
-      <a href="module09.md" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
-      <a href="module11.md" class="module-subcard">11. Synapses and Circuit Logic</a>
+      <a href="module08" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module09" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
+      <a href="module11" class="module-subcard">11. Synapses and Circuit Logic</a>
     </div>
     <p><strong>Character</strong></p>
     <div class="module-subcards">
-      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
-      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+      <a href="module08" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module10" class="module-subcard">10. Network Science & Graph Representation</a>
     </div>
     <p><strong>Meta-Learning</strong></p>
     <div class="module-subcards">
-      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
-      <a href="module09.md" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
-      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+      <a href="module08" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module09" class="module-subcard">09. Neuron Morphology & Skeletonization</a>
+      <a href="module10" class="module-subcard">10. Network Science & Graph Representation</a>
     </div>
     <p><strong>Motivation</strong></p>
     <div class="module-subcards">
-      <a href="module08.md" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
-      <a href="module10.md" class="module-subcard">10. Network Science & Graph Representation</a>
+      <a href="module08" class="module-subcard">08. Hypothesis Testing in Connectomics</a>
+      <a href="module10" class="module-subcard">10. Network Science & Graph Representation</a>
     </div>
   </div>
 
@@ -113,37 +113,37 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <h3>Analysis</h3>
     <p><strong>Knowledge</strong></p>
     <div class="module-subcards">
-      <a href="module12.md" class="module-subcard">12. Big Data in Connectomics</a>
-      <a href="module13.md" class="module-subcard">13. Machine Learning in Neuroscience</a>
-      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
-      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
-      <a href="module20.md" class="module-subcard">20. Statistical Models and Inference</a>
+      <a href="module12" class="module-subcard">12. Big Data in Connectomics</a>
+      <a href="module13" class="module-subcard">13. Machine Learning in Neuroscience</a>
+      <a href="module14" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module15" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module20" class="module-subcard">20. Statistical Models and Inference</a>
     </div>
     <p><strong>Skills</strong></p>
     <div class="module-subcards">
-      <a href="module13.md" class="module-subcard">13. Machine Learning in Neuroscience</a>
-      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
-      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
-      <a href="module18.md" class="module-subcard">18. Data Cleaning and Preprocessing</a>
-      <a href="module19.md" class="module-subcard">19. Visualization for Insight</a>
+      <a href="module13" class="module-subcard">13. Machine Learning in Neuroscience</a>
+      <a href="module14" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module15" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module18" class="module-subcard">18. Data Cleaning and Preprocessing</a>
+      <a href="module19" class="module-subcard">19. Visualization for Insight</a>
     </div>
     <p><strong>Character</strong></p>
     <div class="module-subcards">
-      <a href="module12.md" class="module-subcard">12. Big Data in Connectomics</a>
-      <a href="module13.md" class="module-subcard">13. Machine Learning in Neuroscience</a>
-      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module12" class="module-subcard">12. Big Data in Connectomics</a>
+      <a href="module13" class="module-subcard">13. Machine Learning in Neuroscience</a>
+      <a href="module14" class="module-subcard">14. Computer Vision for EM</a>
     </div>
     <p><strong>Meta-Learning</strong></p>
     <div class="module-subcards">
-      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
-      <a href="module18.md" class="module-subcard">18. Data Cleaning and Preprocessing</a>
-      <a href="module19.md" class="module-subcard">19. Visualization for Insight</a>
-      <a href="module20.md" class="module-subcard">20. Statistical Models and Inference</a>
+      <a href="module15" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module18" class="module-subcard">18. Data Cleaning and Preprocessing</a>
+      <a href="module19" class="module-subcard">19. Visualization for Insight</a>
+      <a href="module20" class="module-subcard">20. Statistical Models and Inference</a>
     </div>
     <p><strong>Motivation</strong></p>
     <div class="module-subcards">
-      <a href="module14.md" class="module-subcard">14. Computer Vision for EM</a>
-      <a href="module15.md" class="module-subcard">15. LLMs for Patch Analysis</a>
+      <a href="module14" class="module-subcard">14. Computer Vision for EM</a>
+      <a href="module15" class="module-subcard">15. LLMs for Patch Analysis</a>
     </div>
   </div>
 
@@ -151,35 +151,35 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <h3>Dissemination</h3>
     <p><strong>Knowledge</strong></p>
     <div class="module-subcards">
-      <a href="module21.md" class="module-subcard">21. Reproducibility and FAIR Principles</a>
-      <a href="module22.md" class="module-subcard">22. Scientific Writing & Presentation</a>
-      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
-      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
-      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+      <a href="module21" class="module-subcard">21. Reproducibility and FAIR Principles</a>
+      <a href="module22" class="module-subcard">22. Scientific Writing & Presentation</a>
+      <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module24" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module25" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
     </div>
     <p><strong>Skills</strong></p>
     <div class="module-subcards">
-      <a href="module22.md" class="module-subcard">22. Scientific Writing & Presentation</a>
-      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
-      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+      <a href="module22" class="module-subcard">22. Scientific Writing & Presentation</a>
+      <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module25" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
     </div>
     <p><strong>Character</strong></p>
     <div class="module-subcards">
-      <a href="module21.md" class="module-subcard">21. Reproducibility and FAIR Principles</a>
-      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
-      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module21" class="module-subcard">21. Reproducibility and FAIR Principles</a>
+      <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module24" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
     </div>
     <p><strong>Meta-Learning</strong></p>
     <div class="module-subcards">
-      <a href="module22.md" class="module-subcard">22. Scientific Writing & Presentation</a>
-      <a href="module23.md" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
-      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
-      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+      <a href="module22" class="module-subcard">22. Scientific Writing & Presentation</a>
+      <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
+      <a href="module24" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module25" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
     </div>
     <p><strong>Motivation</strong></p>
     <div class="module-subcards">
-      <a href="module24.md" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
-      <a href="module25.md" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
+      <a href="module24" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
+      <a href="module25" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
     </div>
   </div>
 </div>
@@ -213,7 +213,7 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
 {% for mod in site.data.modules %}
   <div class="card module-card" data-stage="{{ mod.stage }}" data-ccr="{{ mod.ccr | join: ' ' }}">
     {% assign padded_number = mod.number | plus: 0 | prepend: '0' | slice: -2, 2 %}
-    <a href="module{{ padded_number }}.md" class="module-number-link">{{ padded_number }}. {{ mod.title }}</a>
+    <a href="module{{ padded_number }}" class="module-number-link">{{ padded_number }}. {{ mod.title }}</a>
     <p class="module-description">{{ mod.description }}</p>
   </div>
 {% endfor %}
@@ -239,5 +239,5 @@ ccrSelect.addEventListener('change', filterModules);
 
 ---
 
-Need help deciding where to start? Try **[Module 01](module01.md)** or visit our [Models](/models/) page to learn more about the MERIT and COMPASS frameworks.
+Need help deciding where to start? Try **[Module 01](module01)** or visit our [Models](/models/) page to learn more about the MERIT and COMPASS frameworks.
 


### PR DESCRIPTION
## Summary
- remove `.md` file extensions from module links so they resolve to HTML pages

## Testing
- `jekyll build`
- `linkchecker _site/modules/index.html --check-extern --ignore-url='mailto:' --no-warnings` *(fails: unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68879cfbe800832d8d67a3878e0ba50a