### PR TITLE
Fix quick access card alignment

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="/assets/css/site-styles.css">
+<link rel="stylesheet" href="{{ '/assets/css/site-styles.css' | relative_url }}">

--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -236,6 +236,17 @@ body {
 .card-icon {
   font-size: 2rem;
   margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+}
+
+.module-number,
+.dataset-meta {
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
 }
 
 .card-title {


### PR DESCRIPTION
## Summary
- align quick access card headers by ensuring their icon/meta sections use consistent spacing
- use `relative_url` for custom head stylesheet

## Testing
- `gem install jekyll` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68879d3a3f10832db35d0d80fe97baf7