### PR TITLE
Fix broken avatar links

### DIFF
--- a/avatars/grad-student.md
+++ b/avatars/grad-student.md
@@ -1,3 +1,6 @@
-# grad-student.md
+---
+layout: default
+title: Grad Student – The Newcomer
+---
 
-This is a placeholder for grad-student.md.
+A placeholder biography for the graduate student avatar.

--- a/avatars/index.md
+++ b/avatars/index.md
@@ -1,3 +1,16 @@
-# index.md
+---
+layout: default
+title: Student Avatars
+---
 
-This is a placeholder for index.md.
+Meet the student avatars whose stories illustrate different paths into nanoscale connectomics.
+
+<ul>
+  <li><a href="{{ '/avatars/amir' | relative_url }}">Amir – The Translator</a></li>
+  <li><a href="{{ '/avatars/dr-nguyen' | relative_url }}">Dr. Nguyen – Neuroscience Mentor</a></li>
+  <li><a href="{{ '/avatars/grad-student' | relative_url }}">Grad Student – The Newcomer</a></li>
+  <li><a href="{{ '/avatars/julian' | relative_url }}">Julian – Data Wrangler</a></li>
+  <li><a href="{{ '/avatars/maya' | relative_url }}">Maya – Outreach Champion</a></li>
+  <li><a href="{{ '/avatars/postdoc-ai' | relative_url }}">Postdoc – AI Researcher</a></li>
+  <li><a href="{{ '/avatars/undergrad-firstgen' | relative_url }}">First‑Gen Undergrad</a></li>
+</ul>

--- a/avatars/julian.md
+++ b/avatars/julian.md
@@ -1,5 +1,5 @@
 ---
-layout: archetype
+layout: default
 title: "Julian - First-Generation Undergraduate"
 description: "Meet Julian, a first-generation college student discovering the world of computational neuroscience and finding his path in research."
 student_name: "Julian Rodriguez"

--- a/avatars/postdoc-ai.md
+++ b/avatars/postdoc-ai.md
@@ -1,3 +1,6 @@
-# postdoc-ai.md
+---
+layout: default
+title: Postdoc – AI Researcher
+---
 
-This is a placeholder for postdoc-ai.md.
+A placeholder biography for the postdoctoral avatar focused on AI methods.

--- a/avatars/undergrad-firstgen.md
+++ b/avatars/undergrad-firstgen.md
@@ -1,3 +1,6 @@
-# undergrad-firstgen.md
+---
+layout: default
+title: First-Gen Undergrad
+---
 
-This is a placeholder for undergrad-firstgen.md.
+A placeholder biography for the first-generation undergraduate avatar.

--- a/datasets/mouseconnects.md
+++ b/datasets/mouseconnects.md
@@ -1,3 +1,7 @@
+---
+layout: dataset
+title: "MouseConnects Dataset - Complete Hippocampal Connectome"
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -503,7 +507,7 @@
                 </p>
                 <div class="hero-actions">
                     <a href="#explore-data" class="btn btn-primary btn-large">Explore the Data</a>
-                    <a href="#workflow" class="btn btn-secondary btn-large">View Pipeline</a>
+                    <a href="/datasets/workflow" class="btn btn-secondary btn-large">View Pipeline</a>
                 </div>
             </div>
             <div class="hero-visual">


### PR DESCRIPTION
## Summary
- add avatar index page with links to each avatar
- ensure avatar bio pages include front matter
- convert mouseconnects dataset page to Jekyll collection
- fix pipeline link to dataset workflow

## Testing
- `jekyll build`
- `htmlproofer ./_site --disable-external --allow-hash-href --assume-extension .html`

------
https://chatgpt.com/codex/tasks/task_e_6887a34b5814832dafecc1ac520b1d18