### PR TITLE
Add dataset access link and modules 16/17

### DIFF
--- a/_data/modules.yml
+++ b/_data/modules.yml
@@ -74,15 +74,15 @@
   stage: "Analysis"
   ccr: [Knowledge, Skills, Meta-Learning, Motivation]
 - number: 16
-  title: "Project-Based Research Planning"
-  description: "Scoping, feasibility, and aligning skills with goals."
-  stage: "Analysis"
-  ccr: [Skills]
+  title: "Scientific Visualization for Connectomics"
+  description: "Create effective 2D and 3D visuals to communicate connectome data."
+  stage: "Dissemination"
+  ccr: [Skills, Meta-Learning]
 - number: 17
-  title: "Experimental Design & Controls"
-  description: "Establishing valid comparisons and controlling variables."
-  stage: "Analysis"
-  ccr: [Knowledge, Skills]
+  title: "Scientific Writing for Connectomics"
+  description: "Write clear papers, abstracts, and figure captions for neuroscience audiences."
+  stage: "Dissemination"
+  ccr: [Knowledge, Skills, Character]
 - number: 18
   title: "Data Cleaning and Preprocessing"
   description: "Handling noise, filtering data, and reproducibility."

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -497,6 +497,22 @@ description: "Explore curated connectomics datasets from landmark studies includ
   <section class="section" style="text-align: center;">
     <h2>📂 Accessing These Datasets</h2>
     <p>Most datasets are freely available through dedicated platforms. Each dataset entry above includes direct links to data portals, original publications, and popular press coverage where available.</p>
+
+    <div class="dataset-card featured spotlight" style="text-align: left; margin: 2rem auto; max-width: 600px;">
+      <div class="dataset-header">
+        <div class="dataset-icon">🔧</div>
+        <div class="dataset-meta">
+          <span class="dataset-type">Tutorials</span>
+          <span class="dataset-status">Resources</span>
+        </div>
+      </div>
+      <h3><a href="{{ '/datasets/access' | relative_url }}">Accessing Public EM Datasets</a></h3>
+      <p>Step-by-step guides and example notebooks for downloading connectomics data from Google, the Allen Institute, Janelia, and bossDB.</p>
+      <div class="dataset-actions">
+        <a href="{{ '/datasets/access' | relative_url }}" class="btn btn-primary">View Guide</a>
+      </div>
+    </div>
+
     <div style="margin: 2rem 0;">
       <a href="https://bossdb.org/projects" class="btn btn-primary" target="_blank" style="margin: 0.5rem;">Browse BossDB</a>
       <a href="https://h01-release.storage.googleapis.com/" class="btn btn-secondary" target="_blank" style="margin: 0.5rem;">H01 Portal</a>

--- a/modules/index.md
+++ b/modules/index.md
@@ -151,6 +151,8 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <h3>Dissemination</h3>
     <p><strong>Knowledge</strong></p>
     <div class="module-subcards">
+      <a href="module16" class="module-subcard">16. Scientific Visualization for Connectomics</a>
+      <a href="module17" class="module-subcard">17. Scientific Writing for Connectomics</a>
       <a href="module21" class="module-subcard">21. Reproducibility and FAIR Principles</a>
       <a href="module22" class="module-subcard">22. Scientific Writing & Presentation</a>
       <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
@@ -159,6 +161,8 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     </div>
     <p><strong>Skills</strong></p>
     <div class="module-subcards">
+      <a href="module16" class="module-subcard">16. Scientific Visualization for Connectomics</a>
+      <a href="module17" class="module-subcard">17. Scientific Writing for Connectomics</a>
       <a href="module22" class="module-subcard">22. Scientific Writing & Presentation</a>
       <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
       <a href="module25" class="module-subcard">25. Portfolio, Feedback, and Final Project</a>
@@ -166,11 +170,14 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     <p><strong>Character</strong></p>
     <div class="module-subcards">
       <a href="module21" class="module-subcard">21. Reproducibility and FAIR Principles</a>
+      <a href="module17" class="module-subcard">17. Scientific Writing for Connectomics</a>
       <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
       <a href="module24" class="module-subcard">24. Career Pathways & Graduate School Prep</a>
     </div>
     <p><strong>Meta-Learning</strong></p>
     <div class="module-subcards">
+      <a href="module16" class="module-subcard">16. Scientific Visualization for Connectomics</a>
+      <a href="module17" class="module-subcard">17. Scientific Writing for Connectomics</a>
       <a href="module22" class="module-subcard">22. Scientific Writing & Presentation</a>
       <a href="module23" class="module-subcard">23. Posters, Abstracts, and Conferences</a>
       <a href="module24" class="module-subcard">24. Career Pathways & Graduate School Prep</a>


### PR DESCRIPTION
## Summary
- link to Accessing Public EM Datasets from dataset index with a new card
- show modules 16 and 17 in MERIT matrix
- update modules.yml entries for modules 16 and 17

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a8c7c2ac832db9e61f4657a6c1df