### PR TITLE
Fix stray markdown lines

### DIFF
--- a/datasets/access.md
+++ b/datasets/access.md
@@ -10,7 +10,7 @@ description: "Resources and notebooks for downloading and exploring connectomics
 
 A guide to resources and example notebooks for accessing major public Electron Microscopy (EM) connectomics datasets.
 
----
+<hr>
 
 ## 🧠 Google Research (FAFB & H01)
 
@@ -33,7 +33,7 @@ Google's connectomics team has released several landmark datasets, most famously
         * **Advanced Queries:** Once you're comfortable, this notebook shows how to perform more complex queries, like finding all the inputs to a specific neuron compartment.
             * [**Run the "Queries" Tutorial in Colab**](https://colab.research.google.com/github/seung-lab/PyChunkedGraph/blob/master/notebooks/Queries.ipynb)
 
----
+<hr>
 
 ## 🐭 Allen Institute for Brain Science (MICrONS)
 
@@ -54,7 +54,7 @@ The Allen Institute's MICrONS project produced a cubic millimeter dataset from t
         * **Visualizing Meshes:** This notebook shows how to take the data you've queried and visualize it in 3D.
             * [**Working with Mesh Data Tutorial**](https://github.com/AllenInstitute/MicronsBinder/blob/main/notebooks/meshing.ipynb)
 
----
+<hr>
 
 ## 🪰 Janelia Research Campus / HHMI (Hemibrain)
 
@@ -75,7 +75,7 @@ Janelia's FlyEM team produced the "hemibrain" dataset, a dense reconstruction of
         * **Common Recipes:** This notebook provides solutions for common analysis tasks, such as finding paths between neurons or identifying the strongest inputs to a cell.
             * [**neuPrint Recipes Notebook**](https://github.com/connectome-neuprint/neuprint-python/blob/master/notebooks/Neuprint_Recipes.ipynb)
 
----
+<hr>
 
 ## 💾 bossDB (Multiple Datasets)
 
@@ -94,7 +94,7 @@ The Brain Observatory Storage Service & Database (bossDB) from Johns Hopkins APL
         * **Getting Started with bossDB:** This notebook covers the authentication process, finding data, and downloading a small cutout of EM data.
             * [**bossDB cutout example on GitHub**](https://github.com/jhuapl-boss/intern/blob/master/notebooks/Boss_cutout_example.ipynb)
 
----
+<hr>
 
 ## 🚀 General Tools & Visualization
 

--- a/models.md
+++ b/models.md
@@ -9,7 +9,8 @@ layout: default
   <h1>🧠 Models of Success: MERIT, COMPASS, and CCR</h1>
   <p>Explore the core frameworks guiding the NeuroTrailblazers curriculum — blending structured research training, holistic development, and modern educational theory to support emerging scientists.</p>
 
----
+</div>
+<hr>
 <section class="section">
 <div class="section-header">
   <h2 class="section-title">🔬 MERIT Framework</h2>
@@ -64,8 +65,7 @@ MERIT is a six-stage, merit-based framework for developing talent in computation
   </div>
 </div>
 </section>
-
----
+<hr>
 <section class="section">
 <div class="section-header">
   <h2 class="section-title">🧯 COMPASS Framework</h2>
@@ -130,8 +130,7 @@ COMPASS is a 10-workshop curriculum designed to demystify the hidden curriculum 
   </div>
 </div>
 </section>
-
----
+<hr>
 <section class="section">
 <div class="section-header">
   <h2 class="section-title">🧹 CCR Model</h2>
@@ -161,7 +160,7 @@ The **CCR** model underpins both MERIT and COMPASS by promoting **whole-learner 
 </div>
 
 </section>
----
+<hr>
 
 ## 🔗 References
 
@@ -170,5 +169,5 @@ The **CCR** model underpins both MERIT and COMPASS by promoting **whole-learner 
 * Fadel, C., Bialik, M., & Trilling, B. (2015). *Four-Dimensional Education: The Competencies Learners Need to Succeed*. CCR.
 * Cervantes, C. et al. (2022). CIRCUIT: A framework for inclusive and equitable STEM mentorship. *Cell*, 185(15), 2620–2624.
 
----
+<hr>
 </div>


### PR DESCRIPTION
## Summary
- close hero div on the models page
- replace `---` horizontal rules with `<hr>` tags
- clean dataset access page markdown

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887b47fb58c832d9bd156e81956c035