### PR TITLE
Switch banner image to JPEG

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
 <body>
     <header class="site-header">
         <div class="site-banner">
-            <img src="{{ '/assets/images/neurotrailblazers-banner.png' | relative_url }}" alt="NeuroTrailblazers banner">
+            <img src="{{ '/assets/images/neurotrailblazers-banner.jpg' | relative_url }}" alt="NeuroTrailblazers banner">
         </div>
         <nav class="navbar">
             <a href="{{ '/' | relative_url }}" class="logo">NeuroTrailblazers</a>


### PR DESCRIPTION
## Summary
- use lighter JPG banner in default layout

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6887b829eb88832dbc45c5c5ce6e7860