### PR TITLE
Move mission text to new card

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,15 +9,21 @@ description: "A curriculum and mentorship platform for nanoscale connectomics di
         <section class="hero">
             <div class="hero-content">
                 <h1 class="hero-title-impact"><span class="hero-title-main">Illuminating Pathways for Trailblazing Neuroscience Researchers</span></h1>
-                <div class="hero-description-box">
-                    <p class="hero-description">
-                        We provide content, mentoring, and support to prepare students and their mentors to effectively pursue careers in research.
-                        Closing knowledge and opportunity gaps for students who dream of shaping the future of neuroscience.
-                    </p>
-                </div>
                 <div class="cta-buttons">
                     <a href="{{ '/start-here' | relative_url }}" class="btn btn-primary">Get Started</a>
                     <a href="{{ '/modules/' | relative_url }}" class="btn btn-secondary">Explore Modules</a>
+                </div>
+            </div>
+        </section>
+
+        <!-- Mission Statement Card -->
+        <section class="section">
+            <div class="cards-grid">
+                <div class="card text-center" style="max-width: 600px; margin: 0 auto;">
+                    <p class="card-description">
+                        We provide content, mentoring, and support to prepare students and their mentors to effectively pursue careers in research.
+                        Closing knowledge and opportunity gaps for students who dream of shaping the future of neuroscience.
+                    </p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- move the mission statement out of the hero block
- show mission text in its own card beneath the hero section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b9b91030832dae330019f6304322