### PR TITLE
Improve Jeff Lichtman avatar alt text

### DIFF
--- a/tools/ask-the-expert.md
+++ b/tools/ask-the-expert.md
@@ -16,7 +16,7 @@ permalink: /ask-the-expert/
     </div>
     <div class="hero-visual">
       <div class="expert-avatar">
-        <img src="{{ '/assets/images/jeff-lichtman.jpg' | relative_url }}" alt="Dr. Jeff Lichtman">
+        <img src="{{ '/assets/images/jeff-lichtman.jpg' | relative_url }}" alt="Photo of Dr. Jeff Lichtman">
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- tweak Ask the Expert page so Jeff Lichtman's avatar has descriptive alt text

## Testing
- `jekyll build` *(fails: YAML alias errors but site still builds)*

------
https://chatgpt.com/codex/tasks/task_e_6887ba112cfc832d9e875324841aed5d