### PR TITLE
Fix stray markdown on models page

### DIFF
--- a/education/models.md
+++ b/education/models.md
@@ -7,14 +7,14 @@ This section introduces two core training frameworks used throughout NeuroTrailb
 
 ### MERIT Model
 
-- **M**entoring Exceptional Researchers to Innovate and Thrive. It follows the scientific method from merit-based selection through career transition.
-- Stages: Selection, Orientation, Skill Development, Independent Research, Advanced Research, Career Transition.
-- Anchored in evidence from Lopatto (2007) on undergraduate research experiences and Duckworth et al. (2007) on persistence.
+- **M**entoring Exceptional Researchers to Innovate and Thrive — a six-stage approach that mirrors the scientific method from selection through career transition.
+- **Stages:** Selection, Orientation, Skill Development, Independent Research, Advanced Research, Career Transition.
+- **Evidence base:** Lopatto (2007) on undergraduate research experiences and Duckworth et al. (2007) on persistence.
 
 ### COMPASS Model
 
-- Interactive workshops covering the hidden curriculum from orientation to future planning.
-- Integrates Fadel et al. (2015) four-dimensional education dimensions of knowledge, skills, character, and meta-learning.
+- Interactive workshops that demystify the hidden curriculum from orientation to future planning.
+- Integrates Fadel et al. (2015) four-dimensional education: knowledge, skills, character, and meta-learning.
 
 Both frameworks complement each other: MERIT structures your research journey while COMPASS offers workshops that develop resilience and professional habits.
 

--- a/models.md
+++ b/models.md
@@ -14,8 +14,8 @@ layout: default
 <section class="section">
 <div class="section-header">
   <h2 class="section-title">🔬 MERIT Framework</h2>
-</div>
 
+</div>
 
 **Mentoring Exceptional Researchers to Innovate and Thrive**
 
@@ -164,10 +164,12 @@ The **CCR** model underpins both MERIT and COMPASS by promoting **whole-learner 
 
 ## 🔗 References
 
-* Lopatto, D. (2007). Undergraduate research experiences support science career decisions and active learning. *CBE Life Sci Educ*, 6(4), 297–306.
-* Duckworth, A. et al. (2007). Grit: Perseverance and passion for long-term goals. *J. Pers. Soc. Psychol.*, 92(6), 1087–1101.
-* Fadel, C., Bialik, M., & Trilling, B. (2015). *Four-Dimensional Education: The Competencies Learners Need to Succeed*. CCR.
-* Cervantes, C. et al. (2022). CIRCUIT: A framework for inclusive and equitable STEM mentorship. *Cell*, 185(15), 2620–2624.
+<ul>
+  <li>Lopatto, D. (2007). Undergraduate research experiences support science career decisions and active learning. <em>CBE Life Sci Educ</em>, 6(4), 297–306.</li>
+  <li>Duckworth, A. et al. (2007). Grit: Perseverance and passion for long-term goals. <em>J. Pers. Soc. Psychol.</em>, 92(6), 1087–1101.</li>
+  <li>Fadel, C., Bialik, M., &amp; Trilling, B. (2015). <em>Four-Dimensional Education: The Competencies Learners Need to Succeed</em>. CCR.</li>
+  <li>Cervantes, C. et al. (2022). CIRCUIT: A framework for inclusive and equitable STEM mentorship. <em>Cell</em>, 185(15), 2620–2624.</li>
+</ul>
 
 <hr>
 </div>


### PR DESCRIPTION
## Summary
- clean up stray blank lines in `models.md` and improve reference markup
- polish wording and bullet formatting in `education/models.md`

## Testing
- `mdl models.md | head`
- `mdl education/models.md | head`

------
https://chatgpt.com/codex/tasks/task_e_6887bc89873c832d9ff76f98bffa13c8