### PR TITLE
Fix bare URLs in modules

### DIFF
--- a/modules/module20.md
+++ b/modules/module20.md
@@ -71,8 +71,8 @@ learning\_objectives:
   <section class="section">
     <h2>📚 References & Resources</h2>
     <ul>
-      <li>NIH Grants 101: https://grants.nih.gov/grants/grants_process.htm</li>
-      <li>NSF GRFP Program: https://www.nsfgrfp.org/</li>
+      <li><a href="https://grants.nih.gov/grants/grants_process.htm">NIH Grants 101</a></li>
+      <li><a href="https://www.nsfgrfp.org/">NSF GRFP Program</a></li>
       <li>Colab: "Grant Planning Toolkit and Budget Worksheet"</li>
     </ul>
   </section>

--- a/modules/module23.md
+++ b/modules/module23.md
@@ -71,7 +71,7 @@ learning\_objectives:
   <section class="section">
     <h2>📚 References & Resources</h2>
     <ul>
-      <li>myIDP: https://myidp.sciencecareers.org/</li>
+      <li><a href="https://myidp.sciencecareers.org/">myIDP Career Planning Tool</a></li>
       <li>NeuroJobs and SfN Career Resources</li>
       <li>Colab: "Career Map and Development Plan Generator"</li>
     </ul>


### PR DESCRIPTION
## Summary
- convert plaintext URLs in module20 and module23 to proper anchor tags

## Testing
- `npm install -g markdown-link-check@3.10.3`
- `while read -r url; do curl -Ls -o /dev/null -w "%{http_code} %{url_effective}\n" "$url"; done < /tmp/links2.txt > /tmp/link_status.txt` *(fails: domain not allowlisted)*

------
https://chatgpt.com/codex/tasks/task_e_6887c2e20628832d84aad2a09bfbeb9f