### PR TITLE
Fix models markdown and center card grids

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -277,20 +277,20 @@ body {
 .cards-grid {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   justify-content: center;
   justify-items: center;
 }
 
 .grid-sm {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
 }
 
 .grid-md {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1.5rem;
 }
 
@@ -359,7 +359,7 @@ body {
 .datasets-grid {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   justify-content: center;
   justify-items: center;
 }
@@ -395,7 +395,7 @@ body {
 .modules-grid {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   margin-bottom: 2rem;
   justify-content: center;
   justify-items: center;
@@ -457,7 +457,7 @@ body {
 .merit-matrix {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   margin-bottom: 2rem;
   justify-content: center;
   justify-items: center;
@@ -557,7 +557,9 @@ footer {
 .ccr-boxes {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  justify-content: center;
+  justify-items: center;
 }
 
 .framework-grid .merit-stage,

--- a/models.md
+++ b/models.md
@@ -21,7 +21,7 @@ layout: default
 
 MERIT is a six-stage, merit-based framework for developing talent in computational neuroscience and STEM. It aligns with real scientific workflows, from motivation and exploration through career transition.
 
-> 🔗 See [MERIT Whitepaper PDF](link) for full documentation.
+<p><a href="#">MERIT Whitepaper PDF</a> – full documentation.</p>
 
 <div class="framework-grid">
   <div class="merit-stage">
@@ -75,7 +75,7 @@ MERIT is a six-stage, merit-based framework for developing talent in computation
 
 COMPASS is a 10-workshop curriculum designed to demystify the hidden curriculum in STEM, strengthen research identity, and empower success across diverse student pathways.
 
-> 🔗 See [COMPASS Workshop Guide PDF](link) for full content.
+<p><a href="#">COMPASS Workshop Guide PDF</a> – full content.</p>
 
 <div class="compass-grid">
   <div class="compass-workshop">


### PR DESCRIPTION
## Summary
- clean up blockquote markdown on models page
- tweak grid settings so cards and frameworks center properly

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6887c3308df0832da6328c8cc41d3259