### PR TITLE
Style avatars index, drop icons

### DIFF
--- a/avatars/gradstudent.md
+++ b/avatars/gradstudent.md
@@ -5,14 +5,12 @@ role: Graduate Student
 experience: Intermediate
 epistemic_orientation: Hybrid – computational with curiosity
 motivation: Use ML to push neuroscience forward and lift others with her
-emoji: "🧑‍🔬"
 ---
 
 <div class="main-content">
 <div class="hero hero-spaced hero-rounded">
   <div class="hero-content">
     <div class="avatar-header">
-      <div class="avatar-icon">{{ page.emoji }}</div>
       <div>
         <h1>{{ page.title }}</h1>
         <p class="hero-subtitle">{{ page.role }}</p>

--- a/avatars/index.md
+++ b/avatars/index.md
@@ -1,19 +1,35 @@
 ---
+layout: default
 title: "User Avatars"
-layout: page
+description: "Explore how students, researchers, and mentors navigate their paths into neuroscience."
 ---
 
-# Meet the Trailblazers
+<div class="main-content">
+  <div class="hero hero-spaced hero-rounded">
+    <div class="hero-content">
+      <h1 class="hero-title-impact">Meet the Trailblazers<span>: Inspiring paths into connectomics</span></h1>
+    </div>
+  </div>
 
-This section showcases different user avatars, each representing a journey into the world of neuroscience and connectomics through the NeuroTrailblazers platform.
+  <section class="section">
+    <div class="cards-grid">
+      <a href="{{ '/avatars/undergradstudent' | relative_url }}" class="card text-center">
+        <h3 class="card-title">Julian: Undergraduate Student</h3>
+      </a>
+      <a href="{{ '/avatars/gradstudent' | relative_url }}" class="card text-center">
+        <h3 class="card-title">Maya: Graduate Student</h3>
+      </a>
+      <a href="{{ '/avatars/researcher' | relative_url }}" class="card text-center">
+        <h3 class="card-title">Amir: Researcher</h3>
+      </a>
+      <a href="{{ '/avatars/mentor' | relative_url }}" class="card text-center">
+        <h3 class="card-title">Dr. Nguyen: Mentor/PI</h3>
+      </a>
+    </div>
+  </section>
 
-## Avatars
-
-- [Julian: Undergraduate Student]({{ '/avatars/undergradstudent' | relative_url }})
-- [Maya: Graduate Student]({{ '/avatars/gradstudent' | relative_url }})
-- [Amir: Researcher]({{ '/avatars/researcher' | relative_url }})
-- [Dr. Nguyen: Mentor / Principal Investigator]({{ '/avatars/mentor' | relative_url }})
-
-Each avatar includes a backstory, visible successes, and a noble failure—offering a relatable entry point for diverse learners.
-
-> Inspired by stories like those described in [When Life Gets in the Way of Science](https://www.molbiolcell.org/doi/10.1091/mbc.E24-09-0416)
+  <section class="section">
+    <p>Each avatar includes a backstory, visible successes, and a noble failure—offering a relatable entry point for diverse learners.</p>
+    <p><em>Inspired by stories like those described in <a href="https://www.molbiolcell.org/doi/10.1091/mbc.E24-09-0416">When Life Gets in the Way of Science</a></em></p>
+  </section>
+</div>

--- a/avatars/mentor.md
+++ b/avatars/mentor.md
@@ -5,14 +5,12 @@ role: Postdoc
 experience: Advanced
 epistemic_orientation: Integrative, systems-based
 motivation: Advance connectomics and build healthier research teams
-emoji: "🧑‍🏫"
 ---
 
 <div class="main-content">
 <div class="hero hero-spaced hero-rounded">
   <div class="hero-content">
     <div class="avatar-header">
-      <div class="avatar-icon">{{ page.emoji }}</div>
       <div>
         <h1>{{ page.title }}</h1>
         <p class="hero-subtitle">{{ page.role }}</p>

--- a/avatars/researcher.md
+++ b/avatars/researcher.md
@@ -5,14 +5,12 @@ role: AI Scientist
 experience: Expert (industry)
 epistemic_orientation: Mechanistic, systems optimization
 motivation: Solve big problems, bring vision science into AI
-emoji: "🤖"
 ---
 
 <div class="main-content">
 <div class="hero hero-spaced hero-rounded">
   <div class="hero-content">
     <div class="avatar-header">
-      <div class="avatar-icon">{{ page.emoji }}</div>
       <div>
         <h1>{{ page.title }}</h1>
         <p class="hero-subtitle">{{ page.role }}</p>

--- a/avatars/undergradstudent.md
+++ b/avatars/undergradstudent.md
@@ -2,7 +2,6 @@
 layout: avatar
 title: "Julian - First-Generation Undergraduate"
 description: "Meet Julian, a first-generation college student discovering the world of computational neuroscience and finding his path in research."
-emoji: "👨‍🎓"
 student_name: "Julian Rodriguez"
 education_level: "Undergraduate Sophomore"
 background: "First-generation college student"
@@ -17,7 +16,6 @@ goals: ["Get research experience", "Apply to graduate school", "Make a differenc
 <div class="hero hero-spaced hero-rounded">
   <div class="hero-content">
     <div class="avatar-header">
-      <div class="avatar-icon">{{ page.emoji }}</div>
       <div>
         <h1>{{ page.student_name }}</h1>
         <p class="hero-subtitle">{{ page.background }}</p>


### PR DESCRIPTION
## Summary
- add hero and cards layout on avatars index page
- remove emoji icons from individual avatar pages

## Testing
- `gem install jekyll` *(fails: host mise-versions.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887c43091b0832d8ff99f300d7a804f