### PR TITLE
Fix dataset page layout; add Inter font

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/site-styles.css' | relative_url }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     {% seo %}
 </head>
 <body>

--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -8,7 +8,7 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: var(--brain-gray);
   color: var(--synapse-black);
   margin: 0;

--- a/datasets/mouseconnects.md
+++ b/datasets/mouseconnects.md
@@ -2,13 +2,7 @@
 layout: dataset
 title: "MouseConnects Dataset - Complete Hippocampal Connectome"
 ---
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MouseConnects Dataset - Complete Hippocampal Connectome</title>
-    <style>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -512,8 +506,6 @@ title: "MouseConnects Dataset - Complete Hippocampal Connectome"
             }
         }
     </style>
-</head>
-<body>
     <div class="hero-section gradient-bg">
         <div class="hero-content">
             <div class="hero-text">
@@ -754,5 +746,3 @@ title: "MouseConnects Dataset - Complete Hippocampal Connectome"
             </div>
         </div>
     </footer>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- add Google Fonts link and set Inter as base font
- fix nested HTML in `mouseconnects` dataset page

## Testing
- `tidy -errors -q datasets/mouseconnects.md`
- `tidy -errors -q _layouts/default.html`
- `tidy -errors -q index.html`


------
https://chatgpt.com/codex/tasks/task_e_6887ce925c14832d9b2496d127f84ebc