### PR TITLE
Fix modules dropdown navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,13 +65,7 @@ navigation:
     url: "/datasets/workflow"
   - title: "Modules"
     url: "/modules/"
-    dropdown:
-      - title: "Module 0: Inspiration"
-        url: "/modules/module01/"
-      - title: "Module 1: Introduction"
-        url: "/modules/module02/"
-      - title: "All Modules"
-        url: "/modules/"
+    dropdown: []
   - title: "Datasets"
     url: "/datasets/"
   - title: "Avatars"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,7 +22,15 @@
                 {% for item in site.navigation %}
                 <li class="nav-item">
                     <a href="{{ item.url | relative_url }}" class="nav-link {% if page.url == item.url %}active{% endif %}">{{ item.title }}</a>
-                    {% if item.dropdown %}
+                    {% if item.title == 'Modules' %}
+                    <ul class="dropdown">
+                        {% for mod in site.data.modules limit:5 %}
+                        {% capture numpad %}{{ mod.number | prepend: '0' | slice: -2 }}{% endcapture %}
+                        <li><a href="{{ '/modules/module' | append: numpad | append: '/' | relative_url }}" class="dropdown-link">{{ mod.number | prepend: '0' | slice: -2 }}. {{ mod.title }}</a></li>
+                        {% endfor %}
+                        <li><a href="{{ '/modules/' | relative_url }}" class="dropdown-link">All Modules</a></li>
+                    </ul>
+                    {% elsif item.dropdown %}
                     <ul class="dropdown">
                         {% for subitem in item.dropdown %}
                         <li><a href="{{ subitem.url | relative_url }}" class="dropdown-link">{{ subitem.title }}</a></li>


### PR DESCRIPTION
## Summary
- remove outdated module titles from navigation config
- generate module dropdown dynamically using `_data/modules.yml`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6887de5cc138832dbbb72b9f060e66a3