### PR TITLE
Refine avatar pages

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -792,3 +792,17 @@ footer {
   border-radius: 50%;
   object-fit: cover;
 }
+.avatar-nav {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+.avatar-nav a {
+  color: var(--neural-blue);
+  text-decoration: none;
+  font-weight: 600;
+}
+.avatar-nav a:hover {
+  text-decoration: underline;
+}

--- a/avatars/gradstudent.md
+++ b/avatars/gradstudent.md
@@ -19,22 +19,49 @@ motivation: Use ML to push neuroscience forward and lift others with her
   </div>
 </div>
 
-Maya always straddled two worlds—equally at home in math class and psych lab. She’s now in year 2 of her PhD, building segmentation models and explaining PCA to undergrads.
+<nav class="avatar-nav">
+  <a href="#story">Story</a>
+  <a href="#insights">Insights</a>
+  <a href="{{ '/avatars/' | relative_url }}">All Avatars</a>
+</nav>
 
-She loves when code makes neurons “pop” into clarity. She's not always sure her work counts when she’s not slicing brains or running gels—but she's finding her place.
+<section class="section" id="story">
+  <h2>Maya's Story</h2>
+  <div style="background: var(--brain-gray); padding: 2rem; border-radius: 12px; margin: 1rem 0;">
+    <p style="font-size: 1.1rem; line-height: 1.8; color: var(--synapse-black); margin: 0;">
+      Maya always straddled two worlds—equally at home in math class and psych lab. She’s now in year 2 of her PhD, building segmentation models and explaining PCA to undergrads. She loves when code makes neurons “pop” into clarity. She's not always sure her work counts when she’s not slicing brains or running gels—but she's finding her place.
+    </p>
+  </div>
+</section>
 
-### Inner Conflict:
-- Wants to help others but worries she’s still too new herself
-- Torn between staying in academia or joining a neurotech startup
-- Feels pressure to always be “the explainer” in cross-disciplinary settings
+<section class="section" id="insights">
+  <h2>Key Insights</h2>
+  <div class="cards-grid" style="margin: 2rem 0;">
+    <div class="card" style="border-left: 4px solid var(--neural-blue);">
+      <h3 style="color: var(--neural-blue);">Inner Conflict</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Wants to help others but worries she’s still too new herself</li>
+        <li>Torn between staying in academia or joining a neurotech startup</li>
+        <li>Feels pressure to always be “the explainer” in cross-disciplinary settings</li>
+      </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid var(--cerebral-purple);">
+      <h3 style="color: var(--cerebral-purple);">Journey Markers</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Published reusable Jupyter template for EM visualization</li>
+        <li>Presented on model error modes at a neuroML workshop</li>
+        <li>Started mentoring Julian—and learned as much as she taught</li>
+      </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid var(--axon-cyan);">
+      <h3 style="color: var(--axon-cyan);">Growth Path</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Learns to embrace partial knowledge</li>
+        <li>Gains feedback literacy through peer review</li>
+        <li>Realizes her impact comes from enabling others as much as producing code</li>
+      </ul>
+    </div>
+  </div>
+</section>
 
-### Journey Markers:
-- Published reusable Jupyter template for EM visualization
-- Presented on model error modes at a neuroML workshop
-- Started mentoring Julian—and learned as much as she taught
-
-### Growth Path:
-- Learns to embrace partial knowledge
-- Gains feedback literacy through peer review
-- Realizes her impact comes from enabling others as much as producing code
 </div>

--- a/avatars/mentor.md
+++ b/avatars/mentor.md
@@ -1,7 +1,7 @@
 ---
 layout: avatar
 title: Dr. Nguyen – The Vision Builder
-role: Postdoc
+role: Assistant Professor
 experience: Advanced
 epistemic_orientation: Integrative, systems-based
 motivation: Advance connectomics and build healthier research teams
@@ -19,22 +19,49 @@ motivation: Advance connectomics and build healthier research teams
   </div>
 </div>
 
-Dr. Nguyen has always moved forward—quickly. From valedictorian to PhD to postdoc, she’s led with clarity. But now, managing data releases, peer mentorship, and grant deadlines, she wonders: what’s next?
+<nav class="avatar-nav">
+  <a href="#story">Story</a>
+  <a href="#insights">Insights</a>
+  <a href="{{ '/avatars/' | relative_url }}">All Avatars</a>
+</nav>
 
-She thrives when ideas snap together. But leadership is lonely, and good science often feels at odds with fast science. She’s seen too many teams collapse under pressure.
+<section class="section" id="story">
+  <h2>Nguyen's Story</h2>
+  <div style="background: var(--brain-gray); padding: 2rem; border-radius: 12px; margin: 1rem 0;">
+    <p style="font-size: 1.1rem; line-height: 1.8; color: var(--synapse-black); margin: 0;">
+      Dr. Nguyen has always moved forward—quickly. From valedictorian to PhD to assistant professor, she’s led with clarity. But now, managing data releases, peer mentorship, and grant deadlines, she wonders: what’s next? She thrives when ideas snap together. But leadership is lonely, and good science often feels at odds with fast science. She’s seen too many teams collapse under pressure.
+    </p>
+  </div>
+</section>
 
-### Inner Conflict:
-- Misses days of deep solo work
-- Balancing perfectionism with people-first practices
-- Feels isolated as expectations rise
+<section class="section" id="insights">
+  <h2>Key Insights</h2>
+  <div class="cards-grid" style="margin: 2rem 0;">
+    <div class="card" style="border-left: 4px solid var(--neural-blue);">
+      <h3 style="color: var(--neural-blue);">Inner Conflict</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Misses days of deep solo work</li>
+        <li>Balancing perfectionism with people-first practices</li>
+        <li>Feels isolated as expectations rise</li>
+      </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid var(--cerebral-purple);">
+      <h3 style="color: var(--cerebral-purple);">Journey Markers</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Wrote lab’s first FAIR-compliant annotation protocol</li>
+        <li>Mentored 3 students through their first conference posters</li>
+        <li>Organized cross-lab proofreading challenge to align standards</li>
+      </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid var(--axon-cyan);">
+      <h3 style="color: var(--axon-cyan);">Growth Path</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Sees that leading <em>is</em> science</li>
+        <li>Embraces collaboration as her core contribution</li>
+        <li>Writes grant proposals that prioritize mentorship alongside aims</li>
+      </ul>
+    </div>
+  </div>
+</section>
 
-### Journey Markers:
-- Wrote lab’s first FAIR-compliant annotation protocol
-- Mentored 3 students through their first conference posters
-- Organized cross-lab proofreading challenge to align standards
-
-### Growth Path:
-- Sees that leading *is* science
-- Embraces collaboration as her core contribution
-- Writes grant proposals that prioritize mentorship alongside aims
 </div>

--- a/avatars/researcher.md
+++ b/avatars/researcher.md
@@ -19,22 +19,49 @@ motivation: Solve big problems, bring vision science into AI
   </div>
 </div>
 
-Amir came from the world of edge devices and object tracking. But when he saw a 3D fly brain reconstructed by a global team, he knew: this was the next frontier.
+<nav class="avatar-nav">
+  <a href="#story">Story</a>
+  <a href="#insights">Insights</a>
+  <a href="{{ '/avatars/' | relative_url }}">All Avatars</a>
+</nav>
 
-He’s fluent in models and metrics, but unsure what a dendrite *means*. And he’s learning that science doesn’t move like startups do. But the challenge—that's the hook.
+<section class="section" id="story">
+  <h2>Amir's Story</h2>
+  <div style="background: var(--brain-gray); padding: 2rem; border-radius: 12px; margin: 1rem 0;">
+    <p style="font-size: 1.1rem; line-height: 1.8; color: var(--synapse-black); margin: 0;">
+      Amir came from the world of edge devices and object tracking. But when he saw a 3D fly brain reconstructed by a global team, he knew: this was the next frontier. He’s fluent in models and metrics, but unsure what a dendrite <em>means</em>. And he’s learning that science doesn’t move like startups do. But the challenge—that's the hook.
+    </p>
+  </div>
+</section>
 
-### Inner Conflict:
-- Struggles to read dense neuro papers
-- Unsure when to push his tech or adapt it
-- Wants to contribute but not overstep
+<section class="section" id="insights">
+  <h2>Key Insights</h2>
+  <div class="cards-grid" style="margin: 2rem 0;">
+    <div class="card" style="border-left: 4px solid var(--neural-blue);">
+      <h3 style="color: var(--neural-blue);">Inner Conflict</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Struggles to read dense neuro papers</li>
+        <li>Unsure when to push his tech or adapt it</li>
+        <li>Wants to contribute but not overstep</li>
+      </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid var(--cerebral-purple);">
+      <h3 style="color: var(--cerebral-purple);">Journey Markers</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Tuned a transformer model for segment consistency</li>
+        <li>Co-created a dashboard with a neuro postdoc to evaluate proofread merges</li>
+        <li>Gave a talk that helped PIs understand model bias</li>
+      </ul>
+    </div>
+    <div class="card" style="border-left: 4px solid var(--axon-cyan);">
+      <h3 style="color: var(--axon-cyan);">Growth Path</h3>
+      <ul style="color: #4b5563; margin: 0; font-size: 0.9rem;">
+        <li>Learns from questions, not just answers</li>
+        <li>Redefines “impact” from speed to depth</li>
+        <li>Bridges cultures without diluting either</li>
+      </ul>
+    </div>
+  </div>
+</section>
 
-### Journey Markers:
-- Tuned a transformer model for segment consistency
-- Co-created a dashboard with a neuro postdoc to evaluate proofread merges
-- Gave a talk that helped PIs understand model bias
-
-### Growth Path:
-- Learns from questions, not just answers
-- Redefines “impact” from speed to depth
-- Bridges cultures without diluting either
 </div>

--- a/avatars/undergradstudent.md
+++ b/avatars/undergradstudent.md
@@ -22,10 +22,17 @@ goals: ["Get research experience", "Apply to graduate school", "Make a differenc
         <p style="color: rgba(255,255,255,0.8); margin:0;">{{ page.major }} • {{ page.education_level }}</p>
       </div>
     </div>
-  </div>
+</div>
 </div>
 
-    <section class="section">
+<nav class="avatar-nav">
+  <a href="#story">Story</a>
+  <a href="#goals">Goals</a>
+  <a href="#strengths">Strengths</a>
+  <a href="{{ '/avatars/' | relative_url }}">All Avatars</a>
+</nav>
+
+    <section class="section" id="story">
         <h2>Julian's Story</h2>
         <div style="background: var(--brain-gray); padding: 2rem; border-radius: 12px; margin: 1rem 0;">
             <p style="font-size: 1.1rem; line-height: 1.8; color: var(--synapse-black); margin: 0;">
@@ -58,7 +65,7 @@ goals: ["Get research experience", "Apply to graduate school", "Make a differenc
         </div>
     </section>
 
-    <section class="section">
+    <section class="section" id="goals">
         <h2>🎯 Julian's Goals</h2>
         <p>Julian has clear aspirations but needs guidance on how to achieve them:</p>
 
@@ -98,7 +105,7 @@ goals: ["Get research experience", "Apply to graduate school", "Make a differenc
         </div>
     </section>
 
-    <section class="section">
+    <section class="section" id="strengths">
         <h2>💪 Strengths & Challenges</h2>
         <p>Like many first-generation students, Julian brings unique strengths while facing specific challenges:</p>
 


### PR DESCRIPTION
## Summary
- update mentor to show role as Assistant Professor
- add avatar navigation menu styling
- bring grad, researcher, and mentor avatar pages inline with Julian's layout
- add quick nav links on Julian's page

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6887ddf071fc832d9742a2b64bb31f79