### PR TITLE
Fix module page permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,12 @@ defaults:
     values:
       layout: "module"
   - scope:
+      path: "modules"
+      type: ""
+    values:
+      layout: "module"
+      permalink: "/modules/:basename/"
+  - scope:
       path: ""
       type: "avatars"
     values:

--- a/modules/module01.md
+++ b/modules/module01.md
@@ -2,6 +2,7 @@
 
 title: "Module 01: Introduction to NeuroTrailblazers & Connectomics"
 layout: module
+permalink: /modules/module01/
 ---
 
 ## Overview

--- a/modules/module02.md
+++ b/modules/module02.md
@@ -1,24 +1,25 @@
 ---
-
 title: "Module 02: From Pixels to Projects — Exploring Real Connectomics Datasets"
 layout: module
+permalink: /modules/module02/
 description: "Dive into real-world brain mapping datasets and learn how EM images become 3D digital reconstructions of the brain."
-module\_number: 2
+module_number: 2
 difficulty: "Beginner"
 duration: "2–3 hours"
-learning\_objectives:
-
-* "Describe how raw EM data is acquired and prepared for analysis"
-* "Identify the stages in the connectomics data pipeline (imaging, alignment, segmentation, skeletonization)"
-* "Explore real connectomics datasets using interactive tools"
-* "Recognize different formats (volumes, segments, meshes, skeletons) in current datasets"
-  prerequisites: "Module 1 or equivalent understanding of basic connectomics"
-  merit\_stage: "Orientation & Research Foundations"
-  compass\_skills: \["Digital Literacy", "Data Navigation"]
-  ccr\_focus: \["Knowledge - Data Acquisition", "Skills - Dataset Exploration"]
-
+learning_objectives:
+  - "Describe how raw EM data is acquired and prepared for analysis"
+  - "Identify the stages in the connectomics data pipeline (imaging, alignment, segmentation, skeletonization)"
+  - "Explore real connectomics datasets using interactive tools"
+  - "Recognize different formats (volumes, segments, meshes, skeletons) in current datasets"
+prerequisites: "Module 1 or equivalent understanding of basic connectomics"
+merit_stage: "Orientation & Research Foundations"
+compass_skills:
+  - "Digital Literacy"
+  - "Data Navigation"
+ccr_focus:
+  - "Knowledge - Data Acquisition"
+  - "Skills - Dataset Exploration"
 ---
-
 ```
 <h3 style="margin-top: 1rem;">Core Topics:</h3>
 <ul style="margin-left: 1.5rem;">

--- a/modules/module05.md
+++ b/modules/module05.md
@@ -1,22 +1,25 @@
 ---
-
 title: "Module 05: From Pixels to Proofreading: Image Segmentation and Quality Control"
 layout: module
+permalink: /modules/module05/
 description: "Discover how neural structures are segmented from raw EM images and how humans proofread to ensure accuracy."
-module\_number: 5
+module_number: 5
 difficulty: "Intermediate"
 duration: "3-4 hours"
-learning\_objectives:
-
-* "Explain the concept of image segmentation in connectomics"
-* "Understand the role of neural networks in segmenting EM volumes"
-* "Learn how human proofreading improves segmentation accuracy"
-* "Perform basic proofreading tasks using Neuroglancer"
-  prerequisites: "Module 4 and familiarity with EM imaging"
-  merit\_stage: "Experiment"
-  compass\_skills: \["Scientific Visualization", "Attention to Detail", "Collaboration"]
-  ccr\_focus: \["Skills - Data Integrity", "Character - Grit"]
-
+learning_objectives:
+  - "Explain the concept of image segmentation in connectomics"
+  - "Understand the role of neural networks in segmenting EM volumes"
+  - "Learn how human proofreading improves segmentation accuracy"
+  - "Perform basic proofreading tasks using Neuroglancer"
+prerequisites: "Module 4 and familiarity with EM imaging"
+merit_stage: "Experiment"
+compass_skills:
+  - "Scientific Visualization"
+  - "Attention to Detail"
+  - "Collaboration"
+ccr_focus:
+  - "Skills - Data Integrity"
+  - "Character - Grit"
 ---
 
 <div class="main-content">

--- a/modules/module08.md
+++ b/modules/module08.md
@@ -1,22 +1,25 @@
 ---
-
 title: "Module 08: Hypothesis Testing in Connectomics"
 layout: module
+permalink: /modules/module08/
 description: "Learn how to generate and test scientific hypotheses using circuit-level data from EM volumes."
-module\_number: 8
+module_number: 8
 difficulty: "Intermediate"
 duration: "3-4 hours"
-learning\_objectives:
-
-* "Define and identify testable hypotheses in connectomics"
-* "Apply statistical methods to compare neural features"
-* "Design experiments to validate hypotheses using segmented data"
-* "Critically interpret analysis results"
-  prerequisites: "Modules 1-7, basic statistics"
-  merit\_stage: "Analysis"
-  compass\_skills: \["Scientific Reasoning", "Experimental Design", "Critical Thinking"]
-  ccr\_focus: \["Knowledge - Scientific Inquiry", "Skills - Statistical Analysis"]
-
+learning_objectives:
+  - "Define and identify testable hypotheses in connectomics"
+  - "Apply statistical methods to compare neural features"
+  - "Design experiments to validate hypotheses using segmented data"
+  - "Critically interpret analysis results"
+prerequisites: "Modules 1-7, basic statistics"
+merit_stage: "Analysis"
+compass_skills:
+  - "Scientific Reasoning"
+  - "Experimental Design"
+  - "Critical Thinking"
+ccr_focus:
+  - "Knowledge - Scientific Inquiry"
+  - "Skills - Statistical Analysis"
 ---
 
 <div class="main-content">

--- a/modules/module12.md
+++ b/modules/module12.md
@@ -1,22 +1,25 @@
 ---
-
 title: "Module 12: Functional Annotation and Synapse Typing"
 layout: module
+permalink: /modules/module12/
 description: "Explore how functional roles of synapses and neurons are assigned through morphology and location."
-module\_number: 12
+module_number: 12
 difficulty: "Advanced"
 duration: "3-4 hours"
-learning\_objectives:
-
-* "Describe structural features that correlate with synaptic function"
-* "Classify synapse types from EM images"
-* "Use anatomical position to infer circuit roles"
-* "Compare functional maps with segmentation data"
-  prerequisites: "Modules 1-11, EM segmentation, neuroanatomy basics"
-  merit\_stage: "Analysis"
-  compass\_skills: \["Biological Reasoning", "Classification", "Structure-Function Mapping"]
-  ccr\_focus: \["Knowledge - Neurobiology", "Skills - Morphological Analysis"]
-
+learning_objectives:
+  - "Describe structural features that correlate with synaptic function"
+  - "Classify synapse types from EM images"
+  - "Use anatomical position to infer circuit roles"
+  - "Compare functional maps with segmentation data"
+prerequisites: "Modules 1-11, EM segmentation, neuroanatomy basics"
+merit_stage: "Analysis"
+compass_skills:
+  - "Biological Reasoning"
+  - "Classification"
+  - "Structure-Function Mapping"
+ccr_focus:
+  - "Knowledge - Neurobiology"
+  - "Skills - Morphological Analysis"
 ---
 
 <div class="main-content">


### PR DESCRIPTION
## Summary
- make Jekyll output module pages in `/modules/` subfolders
- add permalinks to modules 01, 02, 05, 08, and 12

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6887de4210bc832db173b7b2ce26a833