### PR TITLE
Improve Start Here checklist style

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -721,26 +721,38 @@ footer {
   border-left: 4px solid var(--axon-cyan);
 }
 .checklist-box {
-  background: var(--brain-gray);
+  background: var(--white);
   padding: 2rem;
   border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 .checklist {
   margin-top: 1rem;
 }
 .checklist label {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   margin: 0.5rem 0;
+  padding: 0.5rem 0.75rem;
+  background: var(--brain-gray);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   cursor: pointer;
+  transition: background 0.3s ease;
 }
 .checklist input[type="checkbox"] {
-  margin-right: 0.5rem;
+  margin-right: 0.25rem;
+  width: 1rem;
+  height: 1rem;
   accent-color: var(--neural-blue);
+  transform: scale(1.1);
+}
+.checklist label span {
+  flex: 1;
 }
 .checklist label:hover {
-  background: rgba(37, 99, 235, 0.05);
-  padding: 0.25rem;
-  border-radius: 4px;
+  background: rgba(37, 99, 235, 0.1);
 }
 .main-content ol,
 .main-content ul {

--- a/start-here.md
+++ b/start-here.md
@@ -139,25 +139,25 @@ description: "Begin your adventure in computational neuroscience with our struct
         <div class="checklist-box">
             <h3>Get Started in 5 Steps:</h3>
             <div class="checklist">
-                <label>
+                <label class="checklist-item">
                     <input type="checkbox">
-                    1. Read this Start Here guide
+                    <span>1. Read this Start Here guide</span>
                 </label>
-                <label>
+                <label class="checklist-item">
                     <input type="checkbox">
-                    2. Choose your learning path above
+                    <span>2. Choose your learning path above</span>
                 </label>
-                <label>
+                <label class="checklist-item">
                     <input type="checkbox">
-                    3. Review the <a href="{{ '/models' | relative_url }}">educational models</a>
+                    <span>3. Review the <a href="{{ '/models' | relative_url }}">educational models</a></span>
                 </label>
-                <label>
+                <label class="checklist-item">
                     <input type="checkbox">
-                    4. Meet your student <a href="{{ '/avatars/' | relative_url }}">avatar</a>
+                    <span>4. Meet your student <a href="{{ '/avatars/' | relative_url }}">avatar</a></span>
                 </label>
-                <label>
+                <label class="checklist-item">
                     <input type="checkbox">
-                    5. Begin your first module!
+                    <span>5. Begin your first module!</span>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle the Quick Start checklist in `start-here.md`
- enhance checklist styles in `site-styles.css`

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_6887dd2d6580832d9b24302980dbe2d0