### PR TITLE
Update quick access icons

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -334,6 +334,15 @@ body {
   min-height: 2rem;
 }
 
+.card-title-with-icon {
+  display: flex;
+  align-items: center;
+}
+
+.icon-inline {
+  margin-right: 0.5rem;
+}
+
 .module-number,
 .dataset-meta {
   margin-bottom: 0.75rem;

--- a/index.html
+++ b/index.html
@@ -146,26 +146,21 @@ description: "A curriculum and mentorship platform for nanoscale connectomics di
                 </div>
                 <div class="cards-grid">
                     <div class="card module-card">
-                        <div class="module-number">Modules</div>
-                        <h3 class="card-title">Learning Modules</h3>
+                        <h3 class="card-title card-title-with-icon"><span class="icon-inline">📚</span> Learning Modules</h3>
                         <p class="card-description">
                             Structured curriculum covering nanoscale connectomics from basic concepts to advanced analysis techniques.
                         </p>
                         <a href="{{ '/modules/' | relative_url }}" class="btn btn-primary mt-1">View All Modules</a>
                     </div>
                     <div class="card dataset-card">
-                        <div class="dataset-meta">
-                            <span class="dataset-year">Datasets</span>
-                        </div>
-                        <h3 class="card-title">Connectomics Datasets</h3>
+                        <h3 class="card-title card-title-with-icon"><span class="icon-inline">🗂️</span> Connectomics Datasets</h3>
                         <p class="card-description">
                             Curated collection of key datasets including Kasthuri, MICrONS, FlyWire, and more.
                         </p>
                         <a href="{{ '/datasets/' | relative_url }}" class="btn btn-primary mt-1">Explore Datasets</a>
                     </div>
                     <div class="card">
-                        <div class="card-icon">👤</div>
-                        <h3 class="card-title">Student Avatars</h3>
+                        <h3 class="card-title card-title-with-icon"><span class="icon-inline">👤</span> Student Avatars</h3>
                         <p class="card-description">
                             Meet Julian, Layla, and Elias - representative student profiles to guide your learning journey.
                         </p>


### PR DESCRIPTION
## Summary
- fix stray text in quick access cards
- add inline icons to the card titles
- style card titles with icons

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_6887e379d370832da1e134f12b53299f