### PR TITLE
Fix module pages layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,8 +25,8 @@
                     {% if item.title == 'Modules' %}
                     <ul class="dropdown">
                         {% for mod in site.data.modules limit:5 %}
-                        {% capture numpad %}{{ mod.number | prepend: '0' | slice: -2 }}{% endcapture %}
-                        <li><a href="{{ '/modules/module' | append: numpad | append: '/' | relative_url }}" class="dropdown-link">{{ mod.number | prepend: '0' | slice: -2 }}. {{ mod.title }}</a></li>
+                        {% capture numpad %}{{ "%02d" | format: mod.number }}{% endcapture %}
+                        <li><a href="{{ '/modules/module' | append: numpad | append: '/' | relative_url }}" class="dropdown-link">{{ "%02d" | format: mod.number }}. {{ mod.title }}</a></li>
                         {% endfor %}
                         <li><a href="{{ '/modules/' | relative_url }}" class="dropdown-link">All Modules</a></li>
                     </ul>

--- a/modules/module01.md
+++ b/modules/module01.md
@@ -3,48 +3,82 @@
 title: "Module 01: Introduction to NeuroTrailblazers & Connectomics"
 layout: module
 permalink: /modules/module01/
+description: "Intro to the NeuroTrailblazers initiative and fundamentals of connectomics."
+module_number: 1
+difficulty: "Beginner"
+duration: "1-2 hours"
 ---
 
-## Overview
+<div class="main-content">
+  <div class="hero">
+    <div class="hero-content">
+      <span class="module-number">Module 01</span>
+      <h1>{{ page.title }}</h1>
+      <p class="hero-subtitle">{{ page.description }}</p>
+    </div>
+  </div>
 
-Welcome to the first step in your NeuroTrailblazers journey. This module introduces the core mission of the NeuroTrailblazers initiative and the exciting field of connectomics. You'll explore why understanding the brain’s wiring matters, how large-scale mapping projects like MICrONS and H01 work, and what tools and skills you’ll gain throughout this curriculum.
 
-## SMART Learning Objectives
+<section class="section">
+  <h2>Overview</h2>
+  <p>Welcome to the first step in your NeuroTrailblazers journey. This module introduces the core mission of the NeuroTrailblazers initiative and the exciting field of connectomics. You'll explore why understanding the brain’s wiring matters, how large-scale mapping projects like MICrONS and H01 work, and what tools and skills you’ll gain throughout this curriculum.</p>
+</section>
 
-By the end of this module, students will be able to:
+<section class="section">
+  <h2>SMART Learning Objectives</h2>
+  <p>By the end of this module, students will be able to:</p>
 
-* **Describe** the goals of connectomics and how it fits within modern neuroscience. *(Bloom: Remember, Understand)*
-* **Identify** major connectomics datasets and their characteristics. *(Bloom: Understand)*
-* **Recognize** the purpose and structure of the NeuroTrailblazers platform. *(Bloom: Remember)*
+  <ul>
+    <li><strong>Describe</strong> the goals of connectomics and how it fits within modern neuroscience. <em>(Bloom: Remember, Understand)</em></li>
+    <li><strong>Identify</strong> major connectomics datasets and their characteristics. <em>(Bloom: Understand)</em></li>
+    <li><strong>Recognize</strong> the purpose and structure of the NeuroTrailblazers platform. <em>(Bloom: Remember)</em></li>
+  </ul>
+</section>
 
-## Training Goals
+<section class="section">
+  <h2>Training Goals</h2>
+  <ul>
+    <li>Inspire students to pursue curiosity-driven discovery in neuroscience.</li>
+    <li>Establish the value of interdisciplinary learning across neuroscience, computation, and ethics.</li>
+    <li>Familiarize learners with key resources and concepts that recur in later modules.</li>
+  </ul>
+</section>
 
-* Inspire students to pursue curiosity-driven discovery in neuroscience.
-* Establish the value of interdisciplinary learning across neuroscience, computation, and ethics.
-* Familiarize learners with key resources and concepts that recur in later modules.
+<section class="section">
+  <h2>Key Resources</h2>
+  <ul>
+    <li><a href="https://www.ted.com/talks/sebastian_seung_i_am_my_connectome">I Am My Connectome – Sebastian Seung (TED)</a></li>
+    <li><a href="https://www.microns-explorer.org/">MICrONS Project Overview</a></li>
+    <li><a href="https://flywire.ai/">FlyWire Dataset from Princeton/HHMI Janelia</a></li>
+  </ul>
+</section>
 
-## Key Resources
+<section class="section">
+  <h2>Sample Colab Notebook</h2>
+  <p>Coming soon – preview of interactive connectome viewer + dataset explorer.</p>
+</section>
 
-* [I Am My Connectome – Sebastian Seung (TED)](https://www.ted.com/talks/sebastian_seung_i_am_my_connectome)
-* [MICrONS Project Overview](https://www.microns-explorer.org/)
-* [FlyWire Dataset from Princeton/HHMI Janelia](https://flywire.ai/)
+<section class="section">
+  <h2>Public Videos / Open Courses</h2>
+  <ul>
+    <li><a href="https://www.brainfacts.org/">BrainFacts.org Intro Series</a></li>
+    <li><a href="https://www.youtube.com/watch?v=qCunr9IeGX8">Jeff Lichtman: Wiring the Brain – YouTube</a></li>
+  </ul>
+</section>
 
-## Sample Colab Notebook
+<section class="section">
+  <h2>Assessment</h2>
+  <ul>
+    <li>Short multiple-choice quiz on core terms and dataset names.</li>
+    <li>Reflection: “What makes connectomics exciting to you?” (Submit 150–250 words)</li>
+  </ul>
+</section>
 
-Coming soon – preview of interactive connectome viewer + dataset explorer.
+<section class="section">
+  <h2>Framework Alignment</h2>
+  <p><strong>MERIT Stage</strong>: Orientation & Research Foundations<br>
+  <strong>CCR Pillars</strong>: Knowledge, Motivation<br>
+  <strong>Scientific Pipeline</strong>: Foundations</p>
+</section>
 
-## Public Videos / Open Courses
-
-* [BrainFacts.org Intro Series](https://www.brainfacts.org/)
-* [Jeff Lichtman: Wiring the Brain – YouTube](https://www.youtube.com/watch?v=qCunr9IeGX8)
-
-## Assessment
-
-* Short multiple-choice quiz on core terms and dataset names.
-* Reflection: “What makes connectomics exciting to you?” (Submit 150–250 words)
-
-## Framework Alignment
-
-**MERIT Stage**: Orientation & Research Foundations
-**CCR Pillars**: Knowledge, Motivation
-**Scientific Pipeline**: Foundations
+</div>

--- a/modules/module02.md
+++ b/modules/module02.md
@@ -20,39 +20,63 @@ ccr_focus:
   - "Knowledge - Data Acquisition"
   - "Skills - Dataset Exploration"
 ---
-```
-<h3 style="margin-top: 1rem;">Core Topics:</h3>
-<ul style="margin-left: 1.5rem;">
-  <li>🖼️ <strong>Volume Imaging:</strong> Acquiring nanoscale slices via serial-section EM</li>
-  <li>🔗 <strong>Image Alignment:</strong> Stitching and registering slices to form coherent volumes</li>
-  <li>🧩 <strong>Segmentation:</strong> Using AI to label pixels and define cell boundaries</li>
-  <li>🕸️ <strong>Skeletonization:</strong> Creating simplified graphs to represent neuron paths</li>
-  <li>🧠 <strong>Dataset Exploration:</strong> FlyWire, MICrONS, H01, FAFB, Kasthuri, and more</li>
-</ul>
-```
 
-### 🧪 Sample Interactive Tools:
+<div class="main-content">
+  <div class="hero">
+    <div class="hero-content">
+      <span class="module-number">Module 02</span>
+      <h1>{{ page.title }}</h1>
+      <p class="hero-subtitle">{{ page.description }}</p>
+    </div>
+  </div>
 
-* [Neuroglancer](https://neuroglancer-demo.appspot.com/)
-* [FlyWire Viewer](https://flywire.ai)
-* [MICrONS Explorer](https://www.microns-explorer.org)
+  <section class="section">
+    <h2>Core Topics</h2>
+    <ul>
+      <li>🖼️ <strong>Volume Imaging:</strong> Acquiring nanoscale slices via serial-section EM</li>
+      <li>🔗 <strong>Image Alignment:</strong> Stitching and registering slices to form coherent volumes</li>
+      <li>🧩 <strong>Segmentation:</strong> Using AI to label pixels and define cell boundaries</li>
+      <li>🕸️ <strong>Skeletonization:</strong> Creating simplified graphs to represent neuron paths</li>
+      <li>🧠 <strong>Dataset Exploration:</strong> FlyWire, MICrONS, H01, FAFB, Kasthuri, and more</li>
+    </ul>
+  </section>
 
-### 🎓 COMPASS Integration:
+  <section class="section">
+    <h2>Sample Interactive Tools</h2>
+    <ul>
+      <li><a href="https://neuroglancer-demo.appspot.com/">Neuroglancer</a></li>
+      <li><a href="https://flywire.ai">FlyWire Viewer</a></li>
+      <li><a href="https://www.microns-explorer.org">MICrONS Explorer</a></li>
+    </ul>
+  </section>
 
-* **Knowledge:** Understand how data is organized and labeled for analysis
-* **Skills:** Navigate viewers, identify structures, interpret metadata
-* **Character:** Patience, attention to detail, and openness to uncertainty
-* **Meta-Learning:** Learn how tools and pipelines evolve across datasets
+  <section class="section">
+    <h2>COMPASS Integration</h2>
+    <ul>
+      <li><strong>Knowledge:</strong> Understand how data is organized and labeled for analysis</li>
+      <li><strong>Skills:</strong> Navigate viewers, identify structures, interpret metadata</li>
+      <li><strong>Character:</strong> Patience, attention to detail, and openness to uncertainty</li>
+      <li><strong>Meta-Learning:</strong> Learn how tools and pipelines evolve across datasets</li>
+    </ul>
+  </section>
 
-### 📚 References & Resources:
+  <section class="section">
+    <h2>References & Resources</h2>
+    <ul>
+      <li><strong>Kasthuri et al., 2015</strong>, Cell – "Saturated reconstruction of neocortex"</li>
+      <li><strong>Zheng et al., 2018</strong>, Nature – FlyWire / FAFB EM volume of adult fly brain</li>
+      <li><strong>MICrONS dataset release</strong>, 2021 – V1 Layer 2/3 mouse volume</li>
+      <li><a href="https://bossdb.org">Allen Institute / BossDB</a></li>
+    </ul>
+  </section>
 
-* **Kasthuri et al., 2015**, Cell – "Saturated reconstruction of neocortex"
-* **Zheng et al., 2018**, Nature – FlyWire / FAFB EM volume of adult fly brain
-* **MICrONS dataset release**, 2021 – V1 Layer 2/3 mouse volume
-* Allen Institute / BossDB: [https://bossdb.org](https://bossdb.org)
+  <section class="section">
+    <h2>Assessment</h2>
+    <ul>
+      <li>Match dataset types to pipeline stages (e.g., segmentation → labeled volume)</li>
+      <li>Navigate a dataset and find one synapse, one neuron, and one glial cell</li>
+      <li>Write a 3–4 sentence description of how segmentation is performed and why it matters</li>
+    </ul>
+  </section>
 
-### ✅ Assessment:
-
-* Match dataset types to pipeline stages (e.g., segmentation → labeled volume)
-* Navigate a dataset and find one synapse, one neuron, and one glial cell
-* Write a 3–4 sentence description of how segmentation is performed and why it matters
+</div>

--- a/modules/module03.md
+++ b/modules/module03.md
@@ -3,72 +3,105 @@
 title: "Module 03: Navigating the Scientific Method in Connectomics"
 layout: module
 description: "Learn how the scientific method guides brain mapping, and develop your ability to ask testable neuroscience questions."
-module\_number: 3
+module_number: 3
 difficulty: "Beginner"
 duration: "2-3 hours"
 prerequisites: "Module 0–2 or equivalent experience with connectomics basics"
-merit\_stage: "Orientation & Research Foundations"
-compass\_skills: \["Research Fundamentals", "Scientific Reasoning"]
-ccr\_focus: \["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"]
+merit_stage: "Orientation & Research Foundations"
+compass_skills: ["Research Fundamentals", "Scientific Reasoning"]
+ccr_focus: ["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"]
 ---
 
-## Overview
+<div class="main-content">
+  <div class="hero">
+    <div class="hero-content">
+      <span class="module-number">Module 03</span>
+      <h1>{{ page.title }}</h1>
+      <p class="hero-subtitle">{{ page.description }}</p>
+    </div>
+  </div>
 
-This module explores the scientific method as applied to connectomics and computational neuroscience. Learners will break down the steps of hypothesis generation, experimental design, data collection, analysis, and interpretation within the context of brain circuit mapping. It also introduces real-world case studies from published connectomics research.
+<section class="section">
+  <h2>Overview</h2>
+  <p>This module explores the scientific method as applied to connectomics and computational neuroscience. Learners will break down the steps of hypothesis generation, experimental design, data collection, analysis, and interpretation within the context of brain circuit mapping. It also introduces real-world case studies from published connectomics research.</p>
+</section>
 
-## SMART Learning Objectives
+<section class="section">
+  <h2>SMART Learning Objectives</h2>
+  <p>By the end of this module, students will be able to:</p>
 
-By the end of this module, students will be able to:
+  <ul>
+    <li><strong>Explain</strong> the steps of the scientific method in the context of neuroscience research. <em>(Bloom: Understand)</em></li>
+    <li><strong>Differentiate</strong> between observational studies and hypothesis-driven experiments. <em>(Bloom: Analyze)</em></li>
+    <li><strong>Formulate</strong> a basic hypothesis related to brain connectivity or structure. <em>(Bloom: Apply, Create)</em></li>
+  </ul>
+</section>
 
-* **Explain** the steps of the scientific method in the context of neuroscience research. *(Bloom: Understand)*
-* **Differentiate** between observational studies and hypothesis-driven experiments. *(Bloom: Analyze)*
-* **Formulate** a basic hypothesis related to brain connectivity or structure. *(Bloom: Apply, Create)*
+<section class="section">
+  <h2>Training Goals</h2>
+  <ul>
+    <li>Connect foundational research methodology with neuroscience-specific challenges.</li>
+    <li>Introduce experimental paradigms in connectomics (e.g., tracing, volume imaging).</li>
+    <li>Empower students to ask tractable, testable scientific questions.</li>
+  </ul>
+</section>
 
-## Training Goals
+<section class="section">
+  <h2>Core Scientific Method Stages (Connectomics Examples)</h2>
+  <ul>
+    <li><strong>Ask a Question</strong> (e.g., How are inhibitory neurons organized?)</li>
+    <li><strong>Formulate a Hypothesis</strong> (e.g., Inhibitory axons preferentially target dendritic shafts)</li>
+    <li><strong>Design an Experiment</strong> (EM volume + cell type labels + tracing)</li>
+    <li><strong>Collect Data</strong> (Segmentations, synapse detection, tracing)</li>
+    <li><strong>Analyze & Interpret</strong> (Statistical testing, visualization)</li>
+  </ul>
+</section>
 
-* Connect foundational research methodology with neuroscience-specific challenges.
-* Introduce experimental paradigms in connectomics (e.g., tracing, volume imaging).
-* Empower students to ask tractable, testable scientific questions.
+<section class="section">
+  <h2>Key Resources</h2>
+  <ul>
+    <li><a href="https://www.khanacademy.org/science/high-school-biology/hs-biology-foundations/hs-the-science-of-biology/a/the-science-of-biology-review">The Scientific Method – Khan Academy</a></li>
+    <li><a href="https://www.scientificamerican.com/article/what-is-connectomics/">Scientific American: Connectomics Primer</a></li>
+    <li>Sample paper: Motta et al., "Dense connectomic reconstruction in layer 4 of the somatosensory cortex."</li>
+  </ul>
+</section>
 
-## Core Scientific Method Stages (Connectomics Examples)
+<section class="section">
+  <h2>Sample Colab Notebook</h2>
+  <p><em>Coming soon</em> – Interactive notebook guiding learners to generate testable hypotheses based on EM datasets.</p>
+</section>
 
-* **Ask a Question** (e.g., How are inhibitory neurons organized?)
-* **Formulate a Hypothesis** (e.g., Inhibitory axons preferentially target dendritic shafts)
-* **Design an Experiment** (EM volume + cell type labels + tracing)
-* **Collect Data** (Segmentations, synapse detection, tracing)
-* **Analyze & Interpret** (Statistical testing, visualization)
+<section class="section">
+  <h2>Public Videos / Open Courses</h2>
+  <ul>
+    <li><a href="https://www.pbs.org/video/the-brains-wiring-l4zydr/">PBS Brain Initiative: The Brain’s Wiring</a></li>
+    <li><a href="https://www.youtube.com/watch?v=t2K6mJkSw9U">How to Read a Scientific Paper – YouTube</a></li>
+  </ul>
+</section>
 
-## Key Resources
+<section class="section">
+  <h2>Assessment</h2>
+  <ul>
+    <li><strong>Worksheet</strong>: Match each step of the scientific method to a real-world connectomics example.</li>
+    <li><strong>Discussion Prompt</strong>: Propose a tractable question that could be answered using electron microscopy (EM) data.</li>
+  </ul>
+</section>
 
-* [The Scientific Method – Khan Academy](https://www.khanacademy.org/science/high-school-biology/hs-biology-foundations/hs-the-science-of-biology/a/the-science-of-biology-review)
-* [Scientific American: Connectomics Primer](https://www.scientificamerican.com/article/what-is-connectomics/)
-* Sample paper: Motta et al., "Dense connectomic reconstruction in layer 4 of the somatosensory cortex."
+<section class="section">
+  <h2>COMPASS Integration</h2>
+  <p>This module integrates key COMPASS skills:</p>
+  <ul>
+    <li><strong>Research Fundamentals</strong>: How to ground investigations in the scientific method.</li>
+    <li><strong>Scientific Reasoning</strong>: Translating big questions into testable hypotheses.</li>
+  </ul>
+  <p>While designed around connectomics, these skills generalize to all STEM research domains. Alternative examples from physics, chemistry, or computational biology may be substituted as needed in class discussions.</p>
+</section>
 
-## Sample Colab Notebook
+<section class="section">
+  <h2>Framework Alignment</h2>
+  <p><strong>MERIT Stage</strong>: Orientation & Research Foundations<br>
+  <strong>CCR Pillars</strong>: Knowledge, Meta-Learning<br>
+  <strong>Scientific Pipeline</strong>: Scientific Question</p>
+</section>
 
-*Coming soon* – Interactive notebook guiding learners to generate testable hypotheses based on EM datasets.
-
-## Public Videos / Open Courses
-
-* [PBS Brain Initiative: The Brain’s Wiring](https://www.pbs.org/video/the-brains-wiring-l4zydr/)
-* [How to Read a Scientific Paper – YouTube](https://www.youtube.com/watch?v=t2K6mJkSw9U)
-
-## Assessment
-
-* **Worksheet**: Match each step of the scientific method to a real-world connectomics example.
-* **Discussion Prompt**: Propose a tractable question that could be answered using electron microscopy (EM) data.
-
-## COMPASS Integration
-
-This module integrates key COMPASS skills:
-
-* **Research Fundamentals**: How to ground investigations in the scientific method.
-* **Scientific Reasoning**: Translating big questions into testable hypotheses.
-
-While designed around connectomics, these skills generalize to all STEM research domains. Alternative examples from physics, chemistry, or computational biology may be substituted as needed in class discussions.
-
-## Framework Alignment
-
-* **MERIT Stage**: Orientation & Research Foundations
-* **CCR Pillars**: Knowledge, Meta-Learning
-* **Scientific Pipeline**: Scientific Question
+</div>


### PR DESCRIPTION
## Summary
- apply consistent markup for module 1–3 with hero sections
- clean up markdown lists and add missing metadata
- format module numbers in navigation dropdown consistently

## Testing
- `gem install jekyll` *(fails: tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_6887e4208f80832d95c8a9db885a229f