### PR TITLE
Fix styling on modules pages

### DIFF
--- a/modules/index.md
+++ b/modules/index.md
@@ -6,7 +6,13 @@ description: "Overview of all 25 modules organized by MERIT stages and CCR dimen
 permalink: /modules/
 ---
 
-# NeuroTrailblazers Training Modules
+<div class="main-content">
+  <div class="hero hero-spaced hero-rounded">
+    <div class="hero-content">
+      <h1 class="hero-title-impact">NeuroTrailblazers Training Modules</h1>
+    </div>
+  </div>
+
 
 This curriculum includes 25 structured modules aligned with the MERIT model (Mentoring Exceptional Researchers to Innovate and Thrive) and the COMPASS framework (Charting Opportunity, Mastery, Purpose, Agency, Skills, and Self). Each module is tagged by its place in the research pipeline and grounded in CCR (Center for Curriculum Redesign) learning dimensions: Knowledge, Skills, Character, Meta-Learning, and Motivation.
 
@@ -247,4 +253,5 @@ ccrSelect.addEventListener('change', filterModules);
 ---
 
 Need help deciding where to start? Try **[Module 01](module01/)** or visit our [Models]({{ '/models/' | relative_url }}) page to learn more about the MERIT and COMPASS frameworks.
+</div>
 

--- a/modules/module01.md
+++ b/modules/module01.md
@@ -12,7 +12,6 @@ duration: "1-2 hours"
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 01</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module02.md
+++ b/modules/module02.md
@@ -24,7 +24,6 @@ ccr_focus:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 02</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module03.md
+++ b/modules/module03.md
@@ -15,7 +15,6 @@ ccr_focus: ["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 03</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module04.md
+++ b/modules/module04.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 04</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module05.md
+++ b/modules/module05.md
@@ -25,7 +25,6 @@ ccr_focus:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 05</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module06.md
+++ b/modules/module06.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 06</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module07.md
+++ b/modules/module07.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 07</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module08.md
+++ b/modules/module08.md
@@ -25,7 +25,6 @@ ccr_focus:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 08</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module09.md
+++ b/modules/module09.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 09</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module10.md
+++ b/modules/module10.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 10</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module11.md
+++ b/modules/module11.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 11</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module12.md
+++ b/modules/module12.md
@@ -25,7 +25,6 @@ ccr_focus:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 12</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module13.md
+++ b/modules/module13.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 13</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module14.md
+++ b/modules/module14.md
@@ -21,7 +21,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 14</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module15.md
+++ b/modules/module15.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 15</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module16.md
+++ b/modules/module16.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 16</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module17.md
+++ b/modules/module17.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 17</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module18.md
+++ b/modules/module18.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 18</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module19.md
+++ b/modules/module19.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 19</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module20.md
+++ b/modules/module20.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 20</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module21.md
+++ b/modules/module21.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 21</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module22.md
+++ b/modules/module22.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 22</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module23.md
+++ b/modules/module23.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 23</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module24.md
+++ b/modules/module24.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 24</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>

--- a/modules/module25.md
+++ b/modules/module25.md
@@ -22,7 +22,6 @@ learning\_objectives:
 <div class="main-content">
   <div class="hero">
     <div class="hero-content">
-      <span class="module-number">Module 25</span>
       <h1>{{ page.title }}</h1>
       <p class="hero-subtitle">{{ page.description }}</p>
     </div>


### PR DESCRIPTION
## Summary
- add hero block to modules index
- remove redundant module numbers from module subpages

## Testing
- `ruby -v`
- `gem install jekyll` *(fails: tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_6887e816cd9c832da2439693dc5f7d6b