### PR TITLE
Show module index on module pages

### DIFF
--- a/_includes/module-index.html
+++ b/_includes/module-index.html
@@ -1,0 +1,50 @@
+## 📚 Full Module Index
+
+<p class="module-filters">
+  <label for="stage-select">Stage:</label>
+  <select id="stage-select">
+    <option value="">All</option>
+    <option value="Foundations">Foundations</option>
+    <option value="Question">Question</option>
+    <option value="Experiment">Experiment</option>
+    <option value="Analysis">Analysis</option>
+    <option value="Dissemination">Dissemination</option>
+  </select>
+  <label for="ccr-select">CCR:</label>
+  <select id="ccr-select">
+    <option value="">All</option>
+    <option value="Knowledge">Knowledge</option>
+    <option value="Skills">Skills</option>
+    <option value="Character">Character</option>
+    <option value="Meta-Learning">Meta-Learning</option>
+    <option value="Motivation">Motivation</option>
+  </select>
+</p>
+
+<div class="modules-grid">
+{% for mod in site.data.modules %}
+  <div class="card module-card stage-{{ mod.stage | downcase | replace: ' ', '-' }}" data-stage="{{ mod.stage }}" data-ccr="{{ mod.ccr | join: ' ' }}">
+    {% assign padded_number = mod.number | plus: 0 | prepend: '0' | slice: -2, 2 %}
+    <a href="{{ '/modules/module' | append: padded_number | append: '/' | relative_url }}" class="module-number-link">{{ padded_number }}. {{ mod.title }}</a>
+    <p class="module-description">{{ mod.description }}</p>
+  </div>
+{% endfor %}
+</div>
+
+<script>
+const stageSelect = document.getElementById('stage-select');
+const ccrSelect = document.getElementById('ccr-select');
+
+function filterModules() {
+  const stage = stageSelect.value;
+  const ccr = ccrSelect.value;
+  document.querySelectorAll('.module-card').forEach(card => {
+    const matchStage = !stage || card.dataset.stage === stage;
+    const matchCcr = !ccr || card.dataset.ccr.includes(ccr);
+    card.style.display = (matchStage && matchCcr) ? '' : 'none';
+  });
+}
+
+stageSelect.addEventListener('change', filterModules);
+ccrSelect.addEventListener('change', filterModules);
+</script>

--- a/_layouts/module.html
+++ b/_layouts/module.html
@@ -2,4 +2,5 @@
 layout: default
 ---
 
+{% include module-index.html %}
 {{ content }}

--- a/modules/index.md
+++ b/modules/index.md
@@ -193,56 +193,7 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
 
 ---
 
-## 📚 Full Module Index
-
-<p class="module-filters">
-  <label for="stage-select">Stage:</label>
-  <select id="stage-select">
-    <option value="">All</option>
-    <option value="Foundations">Foundations</option>
-    <option value="Question">Question</option>
-    <option value="Experiment">Experiment</option>
-    <option value="Analysis">Analysis</option>
-    <option value="Dissemination">Dissemination</option>
-  </select>
-  <label for="ccr-select">CCR:</label>
-  <select id="ccr-select">
-    <option value="">All</option>
-    <option value="Knowledge">Knowledge</option>
-    <option value="Skills">Skills</option>
-    <option value="Character">Character</option>
-    <option value="Meta-Learning">Meta-Learning</option>
-    <option value="Motivation">Motivation</option>
-  </select>
-</p>
-
-<div class="modules-grid">
-{% for mod in site.data.modules %}
-  <div class="card module-card stage-{{ mod.stage | downcase | replace: ' ', '-' }}" data-stage="{{ mod.stage }}" data-ccr="{{ mod.ccr | join: ' ' }}">
-    {% assign padded_number = mod.number | plus: 0 | prepend: '0' | slice: -2, 2 %}
-    <a href="module{{ padded_number }}/" class="module-number-link">{{ padded_number }}. {{ mod.title }}</a>
-    <p class="module-description">{{ mod.description }}</p>
-  </div>
-{% endfor %}
-</div>
-
-<script>
-const stageSelect = document.getElementById('stage-select');
-const ccrSelect = document.getElementById('ccr-select');
-
-function filterModules() {
-  const stage = stageSelect.value;
-  const ccr = ccrSelect.value;
-  document.querySelectorAll('.module-card').forEach(card => {
-    const matchStage = !stage || card.dataset.stage === stage;
-    const matchCcr = !ccr || card.dataset.ccr.includes(ccr);
-    card.style.display = (matchStage && matchCcr) ? '' : 'none';
-  });
-}
-
-stageSelect.addEventListener('change', filterModules);
-ccrSelect.addEventListener('change', filterModules);
-</script>
+{% include module-index.html %}
 
 ---
 


### PR DESCRIPTION
## Summary
- pull out module index HTML into `_includes/module-index.html`
- reuse the module index include on the modules index page
- show the module index at the top of all module pages by updating `module` layout

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6887e828b650832da57805c4c599350e