### PR TITLE
Reorder modules index layout

### DIFF
--- a/modules/index.md
+++ b/modules/index.md
@@ -13,6 +13,8 @@ permalink: /modules/
     </div>
   </div>
 
+{% include module-index.html %}
+
 
 This curriculum includes 25 structured modules aligned with the MERIT model (Mentoring Exceptional Researchers to Innovate and Thrive) and the COMPASS framework (Charting Opportunity, Mastery, Purpose, Agency, Skills, and Self). Each module is tagged by its place in the research pipeline and grounded in CCR (Center for Curriculum Redesign) learning dimensions: Knowledge, Skills, Character, Meta-Learning, and Motivation.
 
@@ -196,12 +198,6 @@ This curriculum includes 25 structured modules aligned with the MERIT model (Men
     </div>
   </div>
 </div>
-
----
-
-{% include module-index.html %}
-
----
 
 Need help deciding where to start? Try **[Module 01](module01/)** or visit our [Models]({{ '/models/' | relative_url }}) page to learn more about the MERIT and COMPASS frameworks.
 </div>


### PR DESCRIPTION
## Summary
- start modules page with the module index grid
- remove the duplicated grid include from the bottom

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6887ea3ef720832d959c9d4f2e2cedb3