### PR TITLE
Improve hero fonts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/site-styles.css' | relative_url }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Oswald:wght@500;700&display=swap" rel="stylesheet">
     {% seo %}
 </head>
 <body>

--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -129,6 +129,8 @@ body {
 .hero h1 {
   font-size: 2rem;
   margin-bottom: 0.5rem;
+  font-family: 'Oswald', sans-serif;
+  letter-spacing: 0.5px;
 }
 
 .hero-subtitle {
@@ -145,6 +147,7 @@ body {
 .hero-title-impact {
   font-size: 2rem;
   margin-bottom: 0.5rem;
+  font-family: 'Oswald', sans-serif;
 }
 
 .hero-title-impact span {
@@ -154,6 +157,7 @@ body {
 
 .hero-title-main {
   font-weight: 700;
+  font-family: 'Oswald', sans-serif;
 }
 
 .hero-title-sub {


### PR DESCRIPTION
## Summary
- include Oswald font in default layout
- use Oswald for hero titles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68882b2ae4c8832dab0ad9e2b35fa124