### PR TITLE
Add tagline section to homepage and models page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,6 +87,12 @@ grant_info:
   focus: "Nanoscale Connectomics"
   mission: "Closing knowledge and opportunity gaps for students who dream of shaping the future of neuroscience"
 
+# Program tagline used across pages
+tagline_lines:
+  - "We power breakthroughs by developing and deploying top research talent."
+  - "Our research incubators equip students and mentors with the tools, guidance, and experience to accelerate innovation across cutting-edge fields such as neuroscience, AI, and decision science."
+  - "Neurotrailblazers applies this framework to the audacious goal of mapping the networks of the brain at the level of individual synaptic connections, and makes tools, training and content available to the CONNECTS community and beyond."
+
 # Color palette
 colors:
   neural_blue: "#2563eb"

--- a/index.html
+++ b/index.html
@@ -28,6 +28,17 @@ description: "A curriculum and mentorship platform for nanoscale connectomics di
             </div>
         </section>
 
+        <!-- Program Tagline -->
+        <section class="section section-highlight">
+            <div class="cards-grid">
+                <div class="card text-center" style="max-width: 700px; margin: 0 auto;">
+                    {% for line in site.tagline_lines %}
+                    <p class="card-description">{{ line }}</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
         <!-- Main Content -->
         <div class="main-content">
             <!-- For Students Section -->

--- a/models.md
+++ b/models.md
@@ -25,6 +25,17 @@ layout: default
   </div>
 </div>
 </section>
+
+<!-- Program Tagline -->
+<section class="section section-highlight">
+<div class="cards-grid">
+  <div class="card text-center" style="max-width: 700px; margin: 0 auto;">
+    {% for line in site.tagline_lines %}
+    <p class="card-description">{{ line }}</p>
+    {% endfor %}
+  </div>
+</div>
+</section>
 <hr>
 <section class="section">
 <div class="section-header">


### PR DESCRIPTION
## Summary
- define `tagline_lines` in `_config.yml`
- show tagline on homepage below mission statement
- show tagline on models page below introductory text

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6888311bf620832dbc79a89a1e2525c1