### PR TITLE
Unify hero title font size

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -153,7 +153,7 @@ body {
 
 .hero-title-impact span {
   font-weight: normal;
-  font-size: 2rem;
+  font-size: 2.5rem;
 }
 
 .hero-title-main {


### PR DESCRIPTION
## Summary
- keep the `hero-title-impact` heading and its subtitle span at the same size

## Testing
- `jekyll -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888327d5e40832dad98bccd769699c9