### PR TITLE
Simplify models page with card layout

### DIFF
--- a/models.md
+++ b/models.md
@@ -38,153 +38,47 @@ layout: default
 </section>
 <hr>
 <section class="section">
-<div class="section-header">
-  <h2 class="section-title">🔬 MERIT Framework</h2>
-
-</div>
-
-<strong>Mentoring Exceptional Researchers to Innovate and Thrive</strong>
-
-MERIT is a six-stage, merit-based framework for developing talent in computational neuroscience and STEM. It aligns with real scientific workflows, from motivation and exploration through career transition.
-
-<p><a href="#">MERIT Whitepaper PDF</a> – full documentation.</p>
-
-<div class="framework-grid">
-  <div class="merit-stage">
-    <div class="merit-icon">⭐</div>
-    <h3>Stage 1: Merit-Based Selection</h3>
-    <p>Identifies high-potential individuals using holistic, equitable evaluations.</p>
-    <p class="merit-components"><strong>Focus:</strong> Potential • Aptitude • Resilience</p>
-    <p class="merit-examples"><strong>Key Practices:</strong> Portfolio review, structured interviews, grit assessment</p>
+<div class="cards-grid">
+  <div class="card">
+    <h3>MERIT Framework</h3>
+    <p class="card-description">Mentoring Exceptional Researchers to Innovate and Thrive</p>
+    <ol class="list-tight">
+      <li>Merit-Based Selection</li>
+      <li>Orientation &amp; Research Foundations</li>
+      <li>Skill Development &amp; Mentored Research</li>
+      <li>Independent Research &amp; Early Dissemination</li>
+      <li>Advanced Research &amp; Professional Networking</li>
+      <li>Career Transition &amp; Lifelong Learning</li>
+    </ol>
+    <p><a href="#">MERIT Whitepaper PDF</a></p>
   </div>
-  <div class="merit-stage">
-    <div class="merit-icon">🎯</div>
-    <h3>Stage 2: Orientation &amp; Research Foundations</h3>
-    <p>Builds foundational research literacy, navigation skills, and scientific mindset.</p>
-    <p class="merit-components"><strong>Focus:</strong> Research culture • Ethics • Knowledge foundations</p>
-    <p class="merit-examples"><strong>Includes:</strong> CCR model introduction, Hidden Curriculum training</p>
+  <div class="card">
+    <h3>COMPASS Framework</h3>
+    <p class="card-description">Charting Opportunity, Mastery, Purpose, Agency, Skills, and Self</p>
+    <ol class="list-tight">
+      <li>Orientation</li>
+      <li>The Resilient STEM Scholar</li>
+      <li>Charting Your Course in Research</li>
+      <li>Building Your STEM Entourage</li>
+      <li>Communicating Science I &amp; II</li>
+      <li>The Savvy Researcher</li>
+      <li>Professional Conduct in STEM</li>
+      <li>STEM Identity &amp; Purpose</li>
+      <li>Future Forward</li>
+    </ol>
+    <p><a href="#">COMPASS Workshop Guide PDF</a></p>
   </div>
-  <div class="merit-stage">
-    <div class="merit-icon">🔬</div>
-    <h3>Stage 3: Skill Development &amp; Mentored Research</h3>
-    <p>Deepens technical ability via immersive, mentored research.</p>
-    <p class="merit-components"><strong>Focus:</strong> Hands-on experience • Tool mastery • Communication</p>
-    <p class="merit-examples"><strong>Includes:</strong> Journal clubs, skill workshops, iterative feedback</p>
-  </div>
-  <div class="merit-stage">
-    <div class="merit-icon">🚀</div>
-    <h3>Stage 4: Independent Research &amp; Early Dissemination</h3>
-    <p>Promotes research autonomy and early scholarly contributions.</p>
-    <p class="merit-components"><strong>Focus:</strong> Hypothesis design • Proposal writing • Internal presentation</p>
-  </div>
-  <div class="merit-stage">
-    <div class="merit-icon">🌐</div>
-    <h3>Stage 5: Advanced Research &amp; Professional Networking</h3>
-    <p>Supports complex research execution and external engagement.</p>
-    <p class="merit-components"><strong>Focus:</strong> Publication • Conferences • Career mapping</p>
-  </div>
-  <div class="merit-stage">
-    <div class="merit-icon">🎓</div>
-    <h3>Stage 6: Career Transition &amp; Lifelong Learning</h3>
-    <p>Equips participants for graduate school, industry, and beyond.</p>
-    <p class="merit-components"><strong>Focus:</strong> Career portfolio • Fellowships • Mentorship loops</p>
+  <div class="card">
+    <h3>CCR Model</h3>
+    <p class="card-description">Center for Curriculum Redesign – 21st Century Competency Framework</p>
+    <ul class="list-tight">
+      <li><strong>Knowledge:</strong> Domain expertise in neuroscience and data science</li>
+      <li><strong>Skills:</strong> Critical thinking, problem solving, communication</li>
+      <li><strong>Character:</strong> Curiosity, resilience, integrity, leadership</li>
+      <li><strong>Meta-Learning:</strong> Planning, self-reflection, adaptation</li>
+    </ul>
   </div>
 </div>
-</section>
-<hr>
-<section class="section">
-<div class="section-header">
-  <h2 class="section-title">🧯 COMPASS Framework</h2>
-</div>
-
-<strong>Charting Opportunity, Mastery, Purpose, Agency, Skills, and Self</strong>
-
-COMPASS is a 10-workshop curriculum designed to demystify the hidden curriculum in STEM, strengthen research identity, and empower success across diverse student pathways.
-
-<p><a href="#">COMPASS Workshop Guide PDF</a> – full content.</p>
-
-<div class="compass-grid">
-  <div class="compass-workshop">
-    <div class="workshop-number">1</div>
-    <h3>🎓 Orientation: Navigating Your STEM Journey</h3>
-    <p>SMART goals • Academic codes • Syllabus deconstruction</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">2</div>
-    <h3>💪 The Resilient STEM Scholar</h3>
-    <p>Growth mindset • Wellness • Imposter syndrome resilience</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">3</div>
-    <h3>🧯 Charting Your Course in Research</h3>
-    <p>Finding research roles • STEM identity • Building purpose</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">4</div>
-    <h3>🤝 Building Your STEM Entourage</h3>
-    <p>Networking • Faculty relationships • Peer communities</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">5</div>
-    <h3>📚 Communicating Science I</h3>
-    <p>Scientific writing • Literature reviews • Citation ethics</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">6</div>
-    <h3>🎤 Communicating Science II</h3>
-    <p>Oral presentations • Visual storytelling • Q&amp;A strategies</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">7</div>
-    <h3>🧠 The Savvy Researcher</h3>
-    <p>Metacognition • Study habits • Time-tracking for research</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">8</div>
-    <h3>👥 Professional Conduct in STEM</h3>
-    <p>Lab ethics • Teamwork • Email etiquette • Feedback literacy</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">9</div>
-    <h3>✨ STEM Identity &amp; Purpose</h3>
-    <p>Belonging • Vision development • Mentorship narratives</p>
-  </div>
-  <div class="compass-workshop">
-    <div class="workshop-number">10</div>
-    <h3>🔮 Future Forward</h3>
-    <p>STEM careers • Fellowships • Portfolios • Vision building</p>
-  </div>
-</div>
-</section>
-<hr>
-<section class="section">
-<div class="section-header">
-  <h2 class="section-title">🧹 CCR Model</h2>
-</div>
-
-<strong>Center for Curriculum Redesign – 21st Century Competency Framework</strong>
-
-The <strong>CCR</strong> model underpins both MERIT and COMPASS by promoting <strong>whole-learner development</strong> across four domains:
-
-<div class="ccr-boxes">
-  <div>
-    <h3>🧠 Knowledge</h3>
-    <p>Core domain expertise, including neuroscience, data science, and research methods.</p>
-  </div>
-  <div>
-    <h3>🛠 Skills</h3>
-    <p>Transferable abilities like critical thinking, problem solving, communication, and collaboration.</p>
-  </div>
-  <div>
-    <h3>🧬 Character</h3>
-    <p>Traits like curiosity, resilience, integrity, and leadership — essential for ethical, meaningful work.</p>
-  </div>
-  <div>
-    <h3>↺ Meta-Learning</h3>
-    <p>“Learning how to learn” — planning, self-reflection, adaptation, and embracing complexity.</p>
-  </div>
-</div>
-
 </section>
 <hr>
 


### PR DESCRIPTION
## Summary
- refactor `models.md` to remove long sections
- present MERIT, COMPASS, and CCR as concise cards

## Testing
- `gem install jekyll` *(fails: tunnel error)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688833f4d1b4832dbc4a2e2b6ec728db