### PR TITLE
Refine module pages layout

### DIFF
--- a/_layouts/module.html
+++ b/_layouts/module.html
@@ -2,5 +2,4 @@
 layout: default
 ---
 
-{% include module-index.html %}
 {{ content }}

--- a/models.md
+++ b/models.md
@@ -11,6 +11,14 @@ layout: default
 
 <section class="section">
 <div class="cards-grid">
+  <div class="card text-center" style="max-width: 600px; margin: 0 auto;">
+    <p><strong>We power breakthroughs by developing and deploying top research talent.</strong></p>
+  </div>
+</div>
+</section>
+
+<section class="section">
+<div class="cards-grid">
   <div class="card text-center" style="max-width: 700px; margin: 0 auto;">
     <p>
       The research incubator model for high-impact science is supported by the core frameworks guiding the NeuroTrailblazers curriculum — blending structured research training, holistic development, and modern educational theory to support emerging scientists.
@@ -30,7 +38,7 @@ layout: default
 <section class="section section-highlight">
 <div class="cards-grid">
   <div class="card text-center" style="max-width: 700px; margin: 0 auto;">
-    {% for line in site.tagline_lines %}
+    {% for line in site.tagline_lines offset:1 %}
     <p class="card-description">{{ line }}</p>
     {% endfor %}
   </div>

--- a/modules/module01.md
+++ b/modules/module01.md
@@ -18,12 +18,13 @@ duration: "1-2 hours"
   </div>
 
 
-<section class="section">
+<div class="cards-grid module-cards">
+<div class="card module-card">
   <h2>Overview</h2>
   <p>Welcome to the first step in your NeuroTrailblazers journey. This module introduces the core mission of the NeuroTrailblazers initiative and the exciting field of connectomics. You'll explore why understanding the brain’s wiring matters, how large-scale mapping projects like MICrONS and H01 work, and what tools and skills you’ll gain throughout this curriculum.</p>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>SMART Learning Objectives</h2>
   <p>By the end of this module, students will be able to:</p>
 
@@ -32,52 +33,53 @@ duration: "1-2 hours"
     <li><strong>Identify</strong> major connectomics datasets and their characteristics. <em>(Bloom: Understand)</em></li>
     <li><strong>Recognize</strong> the purpose and structure of the NeuroTrailblazers platform. <em>(Bloom: Remember)</em></li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Training Goals</h2>
   <ul>
     <li>Inspire students to pursue curiosity-driven discovery in neuroscience.</li>
     <li>Establish the value of interdisciplinary learning across neuroscience, computation, and ethics.</li>
     <li>Familiarize learners with key resources and concepts that recur in later modules.</li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Key Resources</h2>
   <ul>
     <li><a href="https://www.ted.com/talks/sebastian_seung_i_am_my_connectome">I Am My Connectome – Sebastian Seung (TED)</a></li>
     <li><a href="https://www.microns-explorer.org/">MICrONS Project Overview</a></li>
     <li><a href="https://flywire.ai/">FlyWire Dataset from Princeton/HHMI Janelia</a></li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Sample Colab Notebook</h2>
   <p>Coming soon – preview of interactive connectome viewer + dataset explorer.</p>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Public Videos / Open Courses</h2>
   <ul>
     <li><a href="https://www.brainfacts.org/">BrainFacts.org Intro Series</a></li>
     <li><a href="https://www.youtube.com/watch?v=qCunr9IeGX8">Jeff Lichtman: Wiring the Brain – YouTube</a></li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Assessment</h2>
   <ul>
     <li>Short multiple-choice quiz on core terms and dataset names.</li>
     <li>Reflection: “What makes connectomics exciting to you?” (Submit 150–250 words)</li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Framework Alignment</h2>
   <p><strong>MERIT Stage</strong>: Orientation & Research Foundations<br>
   <strong>CCR Pillars</strong>: Knowledge, Motivation<br>
   <strong>Scientific Pipeline</strong>: Foundations</p>
-</section>
+</div>
 
+</div>
 </div>

--- a/modules/module02.md
+++ b/modules/module02.md
@@ -29,7 +29,8 @@ ccr_focus:
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>Core Topics</h2>
     <ul>
       <li>🖼️ <strong>Volume Imaging:</strong> Acquiring nanoscale slices via serial-section EM</li>
@@ -38,18 +39,18 @@ ccr_focus:
       <li>🕸️ <strong>Skeletonization:</strong> Creating simplified graphs to represent neuron paths</li>
       <li>🧠 <strong>Dataset Exploration:</strong> FlyWire, MICrONS, H01, FAFB, Kasthuri, and more</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>Sample Interactive Tools</h2>
     <ul>
       <li><a href="https://neuroglancer-demo.appspot.com/">Neuroglancer</a></li>
       <li><a href="https://flywire.ai">FlyWire Viewer</a></li>
       <li><a href="https://www.microns-explorer.org">MICrONS Explorer</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Understand how data is organized and labeled for analysis</li>
@@ -57,9 +58,9 @@ ccr_focus:
       <li><strong>Character:</strong> Patience, attention to detail, and openness to uncertainty</li>
       <li><strong>Meta-Learning:</strong> Learn how tools and pipelines evolve across datasets</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>References & Resources</h2>
     <ul>
       <li><strong>Kasthuri et al., 2015</strong>, Cell – "Saturated reconstruction of neocortex"</li>
@@ -67,15 +68,16 @@ ccr_focus:
       <li><strong>MICrONS dataset release</strong>, 2021 – V1 Layer 2/3 mouse volume</li>
       <li><a href="https://bossdb.org">Allen Institute / BossDB</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>Assessment</h2>
     <ul>
       <li>Match dataset types to pipeline stages (e.g., segmentation → labeled volume)</li>
       <li>Navigate a dataset and find one synapse, one neuron, and one glial cell</li>
       <li>Write a 3–4 sentence description of how segmentation is performed and why it matters</li>
     </ul>
-  </section>
+  </div>
 
+</div>
 </div>

--- a/modules/module03.md
+++ b/modules/module03.md
@@ -21,12 +21,13 @@ ccr_focus: ["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"
     </div>
   </div>
 
-<section class="section">
+<div class="cards-grid module-cards">
+<div class="card module-card">
   <h2>Overview</h2>
   <p>This module explores the scientific method as applied to connectomics and computational neuroscience. Learners will break down the steps of hypothesis generation, experimental design, data collection, analysis, and interpretation within the context of brain circuit mapping. It also introduces real-world case studies from published connectomics research.</p>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>SMART Learning Objectives</h2>
   <p>By the end of this module, students will be able to:</p>
 
@@ -35,18 +36,18 @@ ccr_focus: ["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"
     <li><strong>Differentiate</strong> between observational studies and hypothesis-driven experiments. <em>(Bloom: Analyze)</em></li>
     <li><strong>Formulate</strong> a basic hypothesis related to brain connectivity or structure. <em>(Bloom: Apply, Create)</em></li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Training Goals</h2>
   <ul>
     <li>Connect foundational research methodology with neuroscience-specific challenges.</li>
     <li>Introduce experimental paradigms in connectomics (e.g., tracing, volume imaging).</li>
     <li>Empower students to ask tractable, testable scientific questions.</li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Core Scientific Method Stages (Connectomics Examples)</h2>
   <ul>
     <li><strong>Ask a Question</strong> (e.g., How are inhibitory neurons organized?)</li>
@@ -55,39 +56,39 @@ ccr_focus: ["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"
     <li><strong>Collect Data</strong> (Segmentations, synapse detection, tracing)</li>
     <li><strong>Analyze & Interpret</strong> (Statistical testing, visualization)</li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Key Resources</h2>
   <ul>
     <li><a href="https://www.khanacademy.org/science/high-school-biology/hs-biology-foundations/hs-the-science-of-biology/a/the-science-of-biology-review">The Scientific Method – Khan Academy</a></li>
     <li><a href="https://www.scientificamerican.com/article/what-is-connectomics/">Scientific American: Connectomics Primer</a></li>
     <li>Sample paper: Motta et al., "Dense connectomic reconstruction in layer 4 of the somatosensory cortex."</li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Sample Colab Notebook</h2>
   <p><em>Coming soon</em> – Interactive notebook guiding learners to generate testable hypotheses based on EM datasets.</p>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Public Videos / Open Courses</h2>
   <ul>
     <li><a href="https://www.pbs.org/video/the-brains-wiring-l4zydr/">PBS Brain Initiative: The Brain’s Wiring</a></li>
     <li><a href="https://www.youtube.com/watch?v=t2K6mJkSw9U">How to Read a Scientific Paper – YouTube</a></li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Assessment</h2>
   <ul>
     <li><strong>Worksheet</strong>: Match each step of the scientific method to a real-world connectomics example.</li>
     <li><strong>Discussion Prompt</strong>: Propose a tractable question that could be answered using electron microscopy (EM) data.</li>
   </ul>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>COMPASS Integration</h2>
   <p>This module integrates key COMPASS skills:</p>
   <ul>
@@ -95,13 +96,14 @@ ccr_focus: ["Knowledge - Scientific Literacy", "Meta-Learning - Problem Framing"
     <li><strong>Scientific Reasoning</strong>: Translating big questions into testable hypotheses.</li>
   </ul>
   <p>While designed around connectomics, these skills generalize to all STEM research domains. Alternative examples from physics, chemistry, or computational biology may be substituted as needed in class discussions.</p>
-</section>
+</div>
 
-<section class="section">
+<div class="card module-card">
   <h2>Framework Alignment</h2>
   <p><strong>MERIT Stage</strong>: Orientation & Research Foundations<br>
   <strong>CCR Pillars</strong>: Knowledge, Meta-Learning<br>
   <strong>Scientific Pipeline</strong>: Scientific Question</p>
-</section>
+</div>
 
+</div>
 </div>

--- a/modules/module04.md
+++ b/modules/module04.md
@@ -28,7 +28,8 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🧭 Mapping the Brain: Gross and Fine Anatomy</h2>
     <p>The brain is organized into regions (e.g., cortex, hippocampus, thalamus) that carry out specialized functions. Each region has distinct anatomy visible at both macroscopic and microscopic levels. Understanding where a dataset comes from is key to interpreting its significance.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
       <li>Microscopic anatomy: cortical layers, hippocampal subfields</li>
       <li>Common brain atlases and reference frameworks</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🏗️ Layers, Columns, and Microcircuits</h2>
     <p>Within brain regions, neurons are arranged in stereotyped patterns. In the cortex, this includes six layers and repeating columnar structures. These features shape how circuits function and must be considered during analysis.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
       <li>Laminar inputs and outputs</li>
       <li>Thalamocortical and corticocortical circuits</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔬 Neuroanatomy in EM Datasets</h2>
     <p>Connectomics volumes may span multiple layers or regions. Accurate annotation requires contextual awareness. Tools like Neuroglancer and 3D viewers can assist in orienting within a dataset.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
       <li>Comparing volumes: MICrONS vs. H01 vs. FlyWire</li>
       <li>Embedding anatomical knowledge into AI workflows</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎯 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Structures of the brain and regional functions</li>
@@ -66,9 +67,9 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
       <li><strong>Character:</strong> Precision, curiosity, discipline</li>
       <li><strong>Meta-Learning:</strong> Mapping new knowledge to spatial structures</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Allen Brain Atlas: <a href="https://portal.brain-map.org">brain-map.org</a></li>
@@ -76,14 +77,15 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
       <li>Human Connectome Project: <a href="https://www.humanconnectome.org">humanconnectome.org</a></li>
       <li>FlyWire Neuroglancer Viewer: <a href="https://flywire.ai">flywire.ai</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Label the six layers of cortex and describe a function of each</li>
       <li>Use an EM viewer to identify region-specific features</li>
       <li>Summarize how brain region impacts connectome structure</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module05.md
+++ b/modules/module05.md
@@ -30,7 +30,8 @@ ccr_focus:
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🧠 What is Segmentation?</h2>
     <p>Segmentation is the process of identifying and labeling structures in an image. In connectomics, this means separating each neurite (axon or dendrite) and assigning it a unique label. Most current approaches rely on deep learning to automate this step.</p>
     <ul>
@@ -38,9 +39,9 @@ ccr_focus:
       <li>U-Net and 3D CNNs</li>
       <li>Segmentation errors: mergers and splits</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🛠️ Proofreading 101</h2>
     <p>No segmentation algorithm is perfect. Humans review and correct the machine-generated output, a process known as proofreading. Tools like Neuroglancer allow users to inspect 3D reconstructions slice-by-slice and validate continuity.</p>
     <ul>
@@ -48,9 +49,9 @@ ccr_focus:
       <li>Using visual cues to spot mergers/splits</li>
       <li>Basic workflow: select, inspect, edit</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔬 Quality Metrics and Feedback Loops</h2>
     <p>Segmentation quality can be quantified using metrics like Rand score and edge accuracy. Proofread corrections can also be used to retrain models, creating a virtuous cycle of improvement.</p>
     <ul>
@@ -58,9 +59,9 @@ ccr_focus:
       <li>Using corrections to improve models</li>
       <li>Tracking proofreading contributions</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎯 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Understanding EM segmentation outputs</li>
@@ -68,23 +69,24 @@ ccr_focus:
       <li><strong>Character:</strong> Persistence, humility, teamwork</li>
       <li><strong>Meta-Learning:</strong> Adapting to evolving tools and methods</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Januszewski et al., 2018. <em>High-precision automated reconstruction of neurons with flood-filling networks</em>. Nature Methods.</li>
       <li>Neuroglancer: <a href="https://github.com/google/neuroglancer">github.com/google/neuroglancer</a></li>
       <li>SNEMI3D Benchmark: <a href="https://cremi.org">cremi.org</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Define and explain the purpose of segmentation in connectomics</li>
       <li>Correct a sample proofreading task using Neuroglancer</li>
       <li>Describe how proofreading improves final circuit reconstructions</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module06.md
+++ b/modules/module06.md
@@ -28,7 +28,8 @@ ccr_focus: \["Knowledge - Scientific Method", "Character - Integrity"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🧠 From Curiosity to Question</h2>
     <p>Every scientific journey begins with a question. In connectomics, questions might concern the structure, connectivity, or variability of specific neural circuits. This module guides you through crafting meaningful and testable hypotheses.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Knowledge - Scientific Method", "Character - Integrity"]
       <li>Generating hypotheses from structure</li>
       <li>Choosing appropriate controls and comparisons</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔬 Designing Connectomic Experiments</h2>
     <p>Using large datasets like MICrONS or FlyWire, researchers can simulate experiments by analyzing connectivity motifs, synapse distributions, or circuit asymmetries. Experimental design involves framing a hypothesis, defining metrics, and selecting analysis techniques.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Knowledge - Scientific Method", "Character - Integrity"]
       <li>Metrics: synapse counts, partner diversity, path length</li>
       <li>Tools for analysis: Python, Neuroglancer, Jupyter</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>⚖️ Pitfalls and Ethics</h2>
     <p>Interpretation of structural data comes with challenges. Structure alone doesn’t reveal function. Hypothesis-driven work in connectomics must acknowledge these limits—and be grounded in ethical research practices.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Knowledge - Scientific Method", "Character - Integrity"]
       <li>Responsible data use and attribution</li>
       <li>Working with animal and human brain data</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎯 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Framing scientific questions in a connectomic context</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Knowledge - Scientific Method", "Character - Integrity"]
       <li><strong>Character:</strong> Scientific honesty and rigor</li>
       <li><strong>Meta-Learning:</strong> Learning from failed or ambiguous results</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Helmstaedter et al., 2013. <em>Connectomic reconstruction of the inner plexiform layer in the mouse retina</em>. Nature.</li>
       <li>FlyWire Tutorials: <a href="https://flywire.ai">flywire.ai</a></li>
       <li>Open Source Analysis: <a href="https://microns-explorer.org">microns-explorer.org</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Write a testable hypothesis based on a sample EM volume</li>
       <li>Describe a potential comparison or control</li>
       <li>Explain a challenge in interpreting structural findings</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module07.md
+++ b/modules/module07.md
@@ -28,7 +28,8 @@ ccr_focus: \["Knowledge - Quantitative Analysis", "Skills - Abstraction"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔗 Circuits as Graphs</h2>
     <p>Connectomics datasets can be transformed into graphs, where nodes represent neurons and edges represent synapses. This abstraction allows mathematical analysis of the brain's structure using tools from graph theory.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Knowledge - Quantitative Analysis", "Skills - Abstraction"]
       <li>Directed vs. undirected graphs</li>
       <li>Weighted edges and multilayer networks</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📈 Network Metrics</h2>
     <p>Network theory provides powerful tools for quantifying connectivity. Key metrics help identify structural features of circuits, such as hubs, communities, and bottlenecks.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Knowledge - Quantitative Analysis", "Skills - Abstraction"]
       <li>Path length and clustering coefficient</li>
       <li>Network motifs and modularity</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🧮 Connectomics in Context</h2>
     <p>Analyzing neural networks allows us to draw comparisons across species and systems. Biological networks may exhibit small-world or scale-free properties, and can be contrasted with artificial networks.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Knowledge - Quantitative Analysis", "Skills - Abstraction"]
       <li>Comparing biological vs. artificial networks</li>
       <li>Limitations of network abstraction</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎯 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Network terminology and brain graph modeling</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Knowledge - Quantitative Analysis", "Skills - Abstraction"]
       <li><strong>Character:</strong> Persistence, openness to complexity</li>
       <li><strong>Meta-Learning:</strong> Building bridges between math and biology</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Sporns, 2010. <em>Networks of the Brain</em>. MIT Press.</li>
       <li>Watts & Strogatz, 1998. <em>Collective dynamics of ‘small-world’ networks</em>. Nature.</li>
       <li>NetworkX Documentation: <a href="https://networkx.org">networkx.org</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Draw a network graph from a small connectome sample</li>
       <li>Compute and interpret degree centrality and clustering coefficient</li>
       <li>Compare two networks (e.g. biological vs. artificial) and describe key differences</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module08.md
+++ b/modules/module08.md
@@ -30,7 +30,8 @@ ccr_focus:
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔬 Scientific Hypotheses in Circuit Neuroscience</h2>
     <p>Hypothesis testing is the foundation of experimental science. In connectomics, hypotheses may concern the structure, function, or variability of brain circuits. These must be formalized in ways that support measurement and comparison.</p>
     <ul>
@@ -38,9 +39,9 @@ ccr_focus:
       <li>Generating predictions from data models</li>
       <li>Null vs. alternative hypotheses</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📊 Statistical Tools</h2>
     <p>Proper testing requires selecting appropriate methods based on sample size, distribution, and effect size. Familiarity with statistical tests is key to avoiding false positives or negatives.</p>
     <ul>
@@ -48,9 +49,9 @@ ccr_focus:
       <li>Multiple comparisons and correction</li>
       <li>Visualizing distributions and error bars</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔍 Hypothesis-Driven Experiments</h2>
     <p>Analysis should be guided by the scientific question, not just exploratory metrics. This section emphasizes how to match your analysis pipeline to your hypothesis.</p>
     <ul>
@@ -58,9 +59,9 @@ ccr_focus:
       <li>Power analysis and sample size estimation</li>
       <li>Reporting significance and effect size</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Hypothesis formulation and statistical testing</li>
@@ -68,23 +69,24 @@ ccr_focus:
       <li><strong>Character:</strong> Scientific integrity, curiosity, patience</li>
       <li><strong>Meta-Learning:</strong> Reflecting on analysis limitations and next steps</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Ghasemi & Zahediasl, 2012. <em>Normality tests for statistical analysis: A guide for non-statisticians</em>. Int J Endocrinol Metab.</li>
       <li>Field et al., 2012. <em>Discovering Statistics Using R</em>. Sage.</li>
       <li>Colab: "Statistical Tests in Python with SciPy"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Identify a testable hypothesis from a neural network dataset</li>
       <li>Use Python to perform a statistical test (e.g. t-test) and interpret the result</li>
       <li>Explain the significance and limitations of the findings</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module09.md
+++ b/modules/module09.md
@@ -28,7 +28,8 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔎 Representing the Brain as a Network</h2>
     <p>Connectomes can be interpreted as graphs, where neurons are nodes and synapses are edges. This abstraction allows us to apply network science to analyze brain structure and function.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
       <li>Directed vs. undirected graphs</li>
       <li>Weighted and unweighted connections</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📊 Key Network Metrics</h2>
     <p>Quantifying the structure of neural graphs helps us uncover patterns of connectivity and information flow.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
       <li>Betweenness and closeness centrality</li>
       <li>Clustering coefficient and small-worldness</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎭 Visualizing Neural Graphs</h2>
     <p>Visual representations help us identify motifs and unusual structures in large connectomic graphs.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
       <li>Highlighting hubs and motifs</li>
       <li>Interactive notebooks and Gephi tools</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎯 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Graph theory concepts applied to neuroscience</li>
@@ -66,9 +67,9 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
       <li><strong>Character:</strong> Curiosity, precision, perseverance</li>
       <li><strong>Meta-Learning:</strong> Transfer of graph concepts to new datasets</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Bassett & Sporns, 2017. <em>Network neuroscience</em>. Nature Neuroscience.</li>
@@ -76,14 +77,15 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
       <li>Colab: <a href="https://colab.research.google.com/">Interactive Graph Metrics in Python</a></li>
       <li>Gephi: <a href="https://gephi.org">gephi.org</a></li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Create a basic graph representation of a neuron-synapse dataset</li>
       <li>Calculate centrality metrics and explain their meaning</li>
       <li>Visualize a simple connectome using network plotting tools</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module10.md
+++ b/modules/module10.md
@@ -28,7 +28,8 @@ ccr_focus: \["Knowledge - Hypothesis Design", "Skills - Experimental Logic", "Ch
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🧐 What is a Hypothesis?</h2>
     <p>A hypothesis is a testable prediction about a biological process. In connectomics, hypotheses often relate to how specific circuits enable computation or behavior.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Knowledge - Hypothesis Design", "Skills - Experimental Logic", "Ch
       <li>Operational definitions and falsifiability</li>
       <li>Examples from published neuroscience studies</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔢 Designing Experiments</h2>
     <p>Hypothesis-driven research requires careful planning. This includes defining variables, controls, and outcome measures that meaningfully reflect circuit function.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Knowledge - Hypothesis Design", "Skills - Experimental Logic", "Ch
       <li>Experimental vs. observational studies</li>
       <li>Confounds and sources of bias</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📈 Testing and Interpretation</h2>
     <p>We explore logic-based approaches, simple statistics, and model-based reasoning to interpret data and draw conclusions.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Knowledge - Hypothesis Design", "Skills - Experimental Logic", "Ch
       <li>Understanding p-values and confidence intervals</li>
       <li>Replicability and interpretation frameworks</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌍 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Principles of experimental design</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Knowledge - Hypothesis Design", "Skills - Experimental Logic", "Ch
       <li><strong>Character:</strong> Scientific humility, rigor, honesty</li>
       <li><strong>Meta-Learning:</strong> Learning from failed hypotheses</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Popper, K. (1959). <em>The Logic of Scientific Discovery</em></li>
       <li>Ioannidis, J. (2005). <em>Why Most Published Research Findings Are False</em>. PLoS Medicine</li>
       <li>Curran-Everett, D. (2000). <em>Statistics 101</em>. Advances in Physiology Education</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Given a hypothesis, design a testable experiment and identify the key variables</li>
       <li>Evaluate a flawed experiment and suggest improvements</li>
       <li>Interpret mock experimental results in light of the hypothesis</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module11.md
+++ b/modules/module11.md
@@ -28,7 +28,8 @@ ccr_focus: \["Knowledge - Machine Learning", "Skills - Model Evaluation"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🤖 What is Machine Learning?</h2>
     <p>Machine learning (ML) is a method of teaching computers to learn from data. In connectomics, ML is used to automatically label parts of the EM volume such as cell boundaries and synapses.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Knowledge - Machine Learning", "Skills - Model Evaluation"]
       <li>Training data and ground truth</li>
       <li>Applications in connectomics</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🧠 Neural Networks and Segmentation</h2>
     <p>We focus on convolutional neural networks (CNNs), which are particularly effective for image tasks. Segmentation models learn to assign a class label to each pixel or voxel.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Knowledge - Machine Learning", "Skills - Model Evaluation"]
       <li>Basic architecture: layers, activation functions</li>
       <li>Loss functions for segmentation</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🛠️ Hands-On Training</h2>
     <p>Use Python and TensorFlow/Keras to define a small segmentation network and train it on provided EM slices.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Knowledge - Machine Learning", "Skills - Model Evaluation"]
       <li>Defining the model</li>
       <li>Training loop and model evaluation</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🎯 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> ML pipeline and architecture</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Knowledge - Machine Learning", "Skills - Model Evaluation"]
       <li><strong>Character:</strong> Patience, problem-solving, experimental rigor</li>
       <li><strong>Meta-Learning:</strong> Learning how algorithms improve with data</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Januszewski et al., 2018. <em>Flood-filling networks</em>. Nature Methods.</li>
       <li>Goodfellow et al., <em>Deep Learning</em>, MIT Press.</li>
       <li>Colab: "Intro to CNNs for EM Segmentation"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Describe how CNNs are applied to EM segmentation</li>
       <li>Train and test a simple ML model on labeled data</li>
       <li>Evaluate accuracy and interpret confusion matrices</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module12.md
+++ b/modules/module12.md
@@ -30,7 +30,8 @@ ccr_focus:
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🧰 Synapse Features and Functions</h2>
     <p>Different synapse types can be inferred from structural features such as size, vesicle count, and shape. This section introduces inhibitory vs. excitatory markers.</p>
     <ul>
@@ -38,9 +39,9 @@ ccr_focus:
       <li>Active zone characteristics</li>
       <li>Neurotransmitter vesicle morphologies</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🤸️‍♂️ Cell Type and Functional Mapping</h2>
     <p>Neuronal identity and location help interpret the roles of different synapses in a network.</p>
     <ul>
@@ -48,9 +49,9 @@ ccr_focus:
       <li>Comparison with known circuit motifs</li>
       <li>Labeling by functional markers</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Neuroanatomy, cell types, neurotransmission</li>
@@ -58,23 +59,24 @@ ccr_focus:
       <li><strong>Character:</strong> Curiosity, attention to biological meaning</li>
       <li><strong>Meta-Learning:</strong> Bridging structure and function iteratively</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Harris & Weinberg, 2012. <em>Ultrastructure of synapses</em>. Brain Res.</li>
       <li>Scheffer et al., 2020. <em>A connectome and analysis of the adult Drosophila central brain</em>. eLife.</li>
       <li>Colab: "Synapse Type Classification from Morphology"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Label synapse types from EM snapshots</li>
       <li>Correlate synapse positions with known neuron roles</li>
       <li>Describe confidence level and biological rationale</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module13.md
+++ b/modules/module13.md
@@ -28,7 +28,8 @@ ccr_focus: \["Skills - Feature Extraction", "Skills - Clustering"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>📊 Feature Engineering</h2>
     <p>Neurons and synapses contain measurable features such as volume, length, branching, and connectivity. Feature selection affects analysis outcomes.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Skills - Feature Extraction", "Skills - Clustering"]
       <li>Normalizing and encoding categorical data</li>
       <li>Dealing with missing values</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📊 Dimensionality Reduction and Clustering</h2>
     <p>Use PCA, UMAP, and t-SNE to compress high-dimensional data. Cluster to identify putative neuron classes or structural types.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Skills - Feature Extraction", "Skills - Clustering"]
       <li>Clustering with K-means and DBSCAN</li>
       <li>Visualizing 2D projections</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Feature representation, unsupervised learning</li>
@@ -56,23 +57,24 @@ ccr_focus: \["Skills - Feature Extraction", "Skills - Clustering"]
       <li><strong>Character:</strong> Comfort with ambiguity, exploration</li>
       <li><strong>Meta-Learning:</strong> Iterative tuning and validation</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Petersen et al., 2021. <em>Cell types in mouse cortex revealed by unsupervised analysis of connectomics</em>. Nature.</li>
       <li>McInnes et al., 2018. <em>UMAP: Uniform Manifold Approximation and Projection</em>. JOSS.</li>
       <li>Colab: "Neuron Embedding and Clustering Pipeline"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Extract a feature matrix from a sample connectome</li>
       <li>Use UMAP or t-SNE to project into 2D space</li>
       <li>Label clusters and infer possible biological types</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module14.md
+++ b/modules/module14.md
@@ -27,34 +27,35 @@ ccr_focus: \["Knowledge - Neuroanatomy", "Skills - Morphometrics"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔄 Neuron Classification Strategies</h2>
     <ul>
       <li>Taxonomies: excitatory vs. inhibitory, projection vs. interneuron</li>
       <li>Features: soma size, dendritic branching, axonal spread</li>
       <li>Tools: NBLAST, NeuroMorpho.org, mesh classifiers</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔄 Morphological Feature Extraction</h2>
     <ul>
       <li>Skeleton-based shape descriptors</li>
       <li>Sholl analysis, path length, bifurcation ratios</li>
       <li>Normalization and comparative metrics</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔄 Functional Implications</h2>
     <ul>
       <li>Linking morphology to electrophysiological role</li>
       <li>Comparing morphologically similar neurons across regions</li>
       <li>Implications for connectivity and computation</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Cell type and morphology principles</li>
@@ -62,23 +63,24 @@ ccr_focus: \["Knowledge - Neuroanatomy", "Skills - Morphometrics"]
       <li><strong>Character:</strong> Attention to detail, curiosity</li>
       <li><strong>Meta-Learning:</strong> Evaluating classification limits and biases</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Ascoli et al., 2007. <em>NeuroMorpho.Org: a central resource for neuronal morphologies</em>. Nat Neurosci.</li>
       <li>Colab: "Quantifying neuron shape using PyTorch and scikit-image"</li>
       <li>Allen Institute Cell Types Database</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Extract morphology features from an EM-reconstructed neuron</li>
       <li>Classify neuron type using known anatomical criteria</li>
       <li>Submit justification and visualizations of your classification</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module15.md
+++ b/modules/module15.md
@@ -28,7 +28,8 @@ ccr_focus: \["Skills - Quality Control", "Skills - Annotation"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔍 Common Error Types</h2>
     <p>Segmentation errors (splits, merges) and synapse mislabels affect downstream analysis. Learn to spot patterns in raw EM imagery and segment overlays.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Skills - Quality Control", "Skills - Annotation"]
       <li>Ghost synapses and missing links</li>
       <li>Boundary ambiguity and stitching artifacts</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📊 Visualization Tools</h2>
     <p>Interactive viewers like Neuroglancer enable efficient quality control. Understand how to use layers and cross-sections for visual checks.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Skills - Quality Control", "Skills - Annotation"]
       <li>Using 3D mesh and skeleton modes</li>
       <li>Spotting errors across slices</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📈 Metrics and Fixes</h2>
     <p>Evaluate accuracy using F1 score, precision, recall, and consistency with ground truth or heuristics. Apply edits or flag errors for correction.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Skills - Quality Control", "Skills - Annotation"]
       <li>Topology-aware metrics</li>
       <li>Manual editing vs. AI-assisted correction</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Common connectomics error modes</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Skills - Quality Control", "Skills - Annotation"]
       <li><strong>Character:</strong> Persistence, accountability</li>
       <li><strong>Meta-Learning:</strong> Recognizing error patterns across datasets</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Funke et al., 2018. <em>Large Scale Image Segmentation with Structured Loss Based Deep Learning for Connectomics</em>. ECCV.</li>
       <li>Motta et al., 2019. <em>Dense connectomic reconstruction in layer 4 of the somatosensory cortex</em>. Science.</li>
       <li>Colab: "Segmentation Proofreading with Neuroglancer"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Locate and document at least 3 segmentation errors in a provided volume</li>
       <li>Use Neuroglancer to propose a correction</li>
       <li>Reflect on how quality control affects downstream analysis</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module16.md
+++ b/modules/module16.md
@@ -28,7 +28,8 @@ ccr_focus: \["Skills - Visualization", "Skills - Interpretation"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>📽 Principles of Scientific Visualization</h2>
     <p>Clear visual communication is essential to science. Understand the principles of effective figure design and when to use specific chart types.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Skills - Visualization", "Skills - Interpretation"]
       <li>Balancing detail vs. clarity</li>
       <li>Designing multi-panel figures</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📊 Tools for Visualization</h2>
     <p>From Python to 3D rendering engines, learn to use available tools for compelling visual outputs.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Skills - Visualization", "Skills - Interpretation"]
       <li>Plotly and dash for interactive dashboards</li>
       <li>Neuroglancer for 3D brain data rendering</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🖌️ Telling a Visual Story</h2>
     <p>Figures should do more than decorate—they should lead to insight. This section explores storytelling through graphics.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Skills - Visualization", "Skills - Interpretation"]
       <li>Ordering panels for narrative flow</li>
       <li>Designing figures for posters and papers</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Principles of data presentation</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Skills - Visualization", "Skills - Interpretation"]
       <li><strong>Character:</strong> Aesthetic judgment, clarity</li>
       <li><strong>Meta-Learning:</strong> Revising and improving figures over time</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Rougier et al., 2014. <em>Ten Simple Rules for Better Figures</em>. PLoS Comp Bio.</li>
       <li>Ware, 2013. <em>Information Visualization: Perception for Design</em>.</li>
       <li>Colab: "Data Visualization with Seaborn and Plotly for Connectomics"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Create a figure to summarize results from a previous module</li>
       <li>Design a multi-panel layout for a hypothetical paper</li>
       <li>Critique sample visualizations for clarity and impact</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module17.md
+++ b/modules/module17.md
@@ -28,7 +28,8 @@ ccr_focus: \["Skills - Scientific Communication", "Character - Precision"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>📜 Scientific Structure and Style</h2>
     <p>Writing conventions for papers in neuroscience and biology include structured formats and discipline-specific expectations.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Skills - Scientific Communication", "Character - Precision"]
       <li>Writing style and tense for scientific clarity</li>
       <li>Common errors and how to avoid them</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📃 From Figures to Text</h2>
     <p>Many manuscripts start with the figures. Learn how to derive narrative and emphasis from visuals.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Skills - Scientific Communication", "Character - Precision"]
       <li>Abstracts that tell the story clearly</li>
       <li>Choosing highlights for cover letters or press</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>💊 Tailoring to Your Audience</h2>
     <p>Whether you're writing for peers, mentors, or the public, different strategies apply. We'll explore style, tone, and jargon for each.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Skills - Scientific Communication", "Character - Precision"]
       <li>Conference posters and presentations</li>
       <li>Press releases and public summaries</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Scientific writing standards</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Skills - Scientific Communication", "Character - Precision"]
       <li><strong>Character:</strong> Attention to detail, clarity</li>
       <li><strong>Meta-Learning:</strong> Learning through revision and peer feedback</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Day & Gastel, 2012. <em>How to Write and Publish a Scientific Paper</em>.</li>
       <li>Gopen & Swan, 1990. <em>The Science of Scientific Writing</em>. American Scientist.</li>
       <li>Colab: "Paper Planning and Abstract Drafting Template"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Write a one-paragraph abstract based on sample results</li>
       <li>Label and caption a set of provided figures</li>
       <li>Critique a sample paper's clarity and flow</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module18.md
+++ b/modules/module18.md
@@ -28,7 +28,8 @@ ccr_focus: \["Skills - Presentation", "Character - Confidence"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🎭 Poster Design Fundamentals</h2>
     <p>Posters should be clear, attractive, and self-explanatory. Learn layout techniques and how to prioritize content.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Skills - Presentation", "Character - Confidence"]
       <li>Font size, spacing, and accessibility</li>
       <li>Color and figure balance</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📄 Poster Templates and Tools</h2>
     <p>Explore poster creation tools and templates. Adapt institutional templates or build your own using design software.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Skills - Presentation", "Character - Confidence"]
       <li>Graphical abstract integration</li>
       <li>Using QR codes, interactive elements</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔊 Preparing Your Elevator Pitch</h2>
     <p>A well-prepared short explanation (1–2 minutes) makes a big impact. Prepare talking points for different audiences.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Skills - Presentation", "Character - Confidence"]
       <li>Adjusting for technical vs. general audiences</li>
       <li>Handling tough or unexpected questions</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Conference culture and poster norms</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Skills - Presentation", "Character - Confidence"]
       <li><strong>Character:</strong> Confidence, preparation</li>
       <li><strong>Meta-Learning:</strong> Self-evaluation through feedback</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Rowe, 2017. <em>Designing Conference Posters</em>.</li>
       <li>Schimel, 2012. <em>Writing Science: How to Write Papers That Get Cited and Proposals That Get Funded</em>.</li>
       <li>Colab: "Poster Planning Worksheet and Checklist"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Draft a one-page scientific poster with figure layout</li>
       <li>Practice a 90-second oral summary of your project</li>
       <li>Receive feedback from a peer or mentor on poster clarity</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module19.md
+++ b/modules/module19.md
@@ -28,7 +28,8 @@ ccr_focus: \["Character - Scientific Ethics", "Meta-Learning - Reflective Practi
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>✍️ Understanding Peer Review</h2>
     <p>Peer review maintains quality and credibility in science. Learn how reviewers evaluate manuscripts and how to respond to feedback as an author.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Character - Scientific Ethics", "Meta-Learning - Reflective Practi
       <li>Writing constructive and fair reviews</li>
       <li>Interpreting reviewer comments</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>⚖️ Ethics in Scientific Research</h2>
     <p>Ethical science goes beyond compliance—it’s foundational. Learn to navigate tricky scenarios with clarity and accountability.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Character - Scientific Ethics", "Meta-Learning - Reflective Practi
       <li>Conflict of interest and disclosure</li>
       <li>Data sharing and transparency</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🤝 Authorship and Collaboration</h2>
     <p>Teamwork requires clear expectations. Understand how authorship is determined and how to resolve disputes respectfully.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Character - Scientific Ethics", "Meta-Learning - Reflective Practi
       <li>Co-first authorship and contributorship models</li>
       <li>Navigating lab hierarchies and mentor relationships</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Peer review structures, ethics standards</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Character - Scientific Ethics", "Meta-Learning - Reflective Practi
       <li><strong>Character:</strong> Integrity, respect, responsibility</li>
       <li><strong>Meta-Learning:</strong> Learning through ethical reflection</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Committee on Publication Ethics (COPE) Guidelines</li>
       <li>Resnik, 2011. <em>What is Ethics in Research & Why is it Important?</em></li>
       <li>Colab: "Ethical Case Study Discussions"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Write a mock peer review of a provided abstract</li>
       <li>Identify ethical issues in a sample scenario</li>
       <li>Reflect on a time you faced a question of integrity</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module20.md
+++ b/modules/module20.md
@@ -28,7 +28,8 @@ ccr_focus: \["Skills - Grant Writing", "Knowledge - Research Landscape"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>📄 Anatomy of a Grant Proposal</h2>
     <p>Explore the key sections of a grant proposal and their function in convincing reviewers to support your project.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Skills - Grant Writing", "Knowledge - Research Landscape"]
       <li>Innovation and Approach</li>
       <li>Biosketches and supporting documents</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 Finding Funding</h2>
     <p>There are many funding sources for early-stage researchers. Learn how to match your work to the right opportunities.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Skills - Grant Writing", "Knowledge - Research Landscape"]
       <li>NSF graduate fellowships and research supplements</li>
       <li>Private foundations and institutional seed funds</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📊 Budgeting and Timelines</h2>
     <p>Plan a realistic scope of work with clear milestones and appropriate resource requests.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Skills - Grant Writing", "Knowledge - Research Landscape"]
       <li>Personnel, equipment, and travel costs</li>
       <li>Timeline Gantt charts</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Funding agencies and mechanisms</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Skills - Grant Writing", "Knowledge - Research Landscape"]
       <li><strong>Character:</strong> Initiative, strategic thinking</li>
       <li><strong>Meta-Learning:</strong> Learning through proposal iteration and feedback</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li><a href="https://grants.nih.gov/grants/grants_process.htm">NIH Grants 101</a></li>
       <li><a href="https://www.nsfgrfp.org/">NSF GRFP Program</a></li>
       <li>Colab: "Grant Planning Toolkit and Budget Worksheet"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Write a 1-page draft of Specific Aims</li>
       <li>Identify 3 potential funding sources and summarize their fit</li>
       <li>Draft a budget and timeline for a sample project</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module21.md
+++ b/modules/module21.md
@@ -28,7 +28,8 @@ ccr_focus: \["Character - Leadership", "Skills - Mentorship"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔗 Principles of Mentorship</h2>
     <p>Explore what makes mentorship effective for both mentor and mentee in a research setting.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Character - Leadership", "Skills - Mentorship"]
       <li>Active listening and feedback</li>
       <li>Setting expectations and goals</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>👥 Leadership in Collaborative Science</h2>
     <p>Science is a team effort. Learn to manage group dynamics and lead with inclusion and strategy.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Character - Leadership", "Skills - Mentorship"]
       <li>Facilitating group decision-making</li>
       <li>Conflict resolution and accountability</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🧡 Inclusive Mentorship Practices</h2>
     <p>Inclusive mentorship supports the growth of all team members, especially those from underrepresented backgrounds.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Character - Leadership", "Skills - Mentorship"]
       <li>Addressing stereotype threat and impostor syndrome</li>
       <li>Recognizing and supporting diverse identities</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Mentorship models, leadership frameworks</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Character - Leadership", "Skills - Mentorship"]
       <li><strong>Character:</strong> Empathy, humility, service</li>
       <li><strong>Meta-Learning:</strong> Learning from mentoring experiences</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Johnson, 2015. <em>On Being a Mentor</em></li>
       <li>NASEM, 2019. <em>The Science of Effective Mentorship in STEMM</em></li>
       <li>Colab: "Mentor Scenario Role-Play Toolkit"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Reflect on your mentorship experiences and values</li>
       <li>Draft a mentorship compact or philosophy</li>
       <li>Facilitate a mock research team meeting with roles</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module22.md
+++ b/modules/module22.md
@@ -28,7 +28,8 @@ ccr_focus: \["Character - Scientific Citizenship", "Skills - Public Speaking"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🔊 Explaining Science Clearly</h2>
     <p>Break down technical concepts using analogies, plain language, and compelling visuals.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Character - Scientific Citizenship", "Skills - Public Speaking"]
       <li>Finding your core message</li>
       <li>Using storytelling to build interest</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📺 Outreach Formats and Strategies</h2>
     <p>Choose the best format and channel to reach your audience effectively and ethically.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Character - Scientific Citizenship", "Skills - Public Speaking"]
       <li>Podcast and video content for broader reach</li>
       <li>Engaging with community organizations and advocacy</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📍 Scientist as Citizen</h2>
     <p>Scientists have societal responsibilities. Explore ways to advocate for evidence and science-informed decision-making.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Character - Scientific Citizenship", "Skills - Public Speaking"]
       <li>Equity in science communication</li>
       <li>Reflections on science and trust</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Science literacy and outreach strategies</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Character - Scientific Citizenship", "Skills - Public Speaking"]
       <li><strong>Character:</strong> Civic responsibility, humility</li>
       <li><strong>Meta-Learning:</strong> Learning through audience feedback</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Baram-Tsabari & Osborne, 2015. <em>Bridging Science Education and Science Communication</em></li>
       <li>Marsh, 2020. <em>Science Storytelling for Public Engagement</em></li>
       <li>Colab: "Science for Everyone: Translating Your Research"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Create a 3-minute explainer for a general audience</li>
       <li>Draft a press release or public summary of a research paper</li>
       <li>Design a social media science post (image + caption)</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module23.md
+++ b/modules/module23.md
@@ -28,7 +28,8 @@ ccr_focus: \["Meta-Learning - Career Reflection", "Skills - Pathway Mapping"]
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>💼 Neuroscience Career Landscapes</h2>
     <p>Discover the breadth of careers possible in neuroscience and connectomics research.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Meta-Learning - Career Reflection", "Skills - Pathway Mapping"]
       <li>Industry roles in biotech, neurotech, and pharma</li>
       <li>Science communication, policy, and education</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔹 Building Your Career Toolkit</h2>
     <p>Each path has different preparation requirements. Learn to align your experience and identify gaps.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Meta-Learning - Career Reflection", "Skills - Pathway Mapping"]
       <li>Finding and reaching out to mentors</li>
       <li>Graduate school vs. industry decisions</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>💼 Creating an Individual Development Plan</h2>
     <p>Use IDPs to map your goals, milestones, and resources over time to support intentional development.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Meta-Learning - Career Reflection", "Skills - Pathway Mapping"]
       <li>SMART goals for growth</li>
       <li>Iterating based on new opportunities</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Career types, hiring criteria</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Meta-Learning - Career Reflection", "Skills - Pathway Mapping"]
       <li><strong>Character:</strong> Self-reflection, openness</li>
       <li><strong>Meta-Learning:</strong> Career planning and adaptation</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li><a href="https://myidp.sciencecareers.org/">myIDP Career Planning Tool</a></li>
       <li>NeuroJobs and SfN Career Resources</li>
       <li>Colab: "Career Map and Development Plan Generator"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Explore 3 different neuroscience careers and summarize requirements</li>
       <li>Draft a personal IDP with goals and timelines</li>
       <li>Practice outreach to a potential mentor with an email draft</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module24.md
+++ b/modules/module24.md
@@ -28,7 +28,8 @@ ccr_focus: \["Meta-Learning - Pattern Recognition", "Skills - Interdisciplinary 
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🌎 Foundations of Systems Thinking</h2>
     <p>Systems thinking helps you understand complex interactions, feedback, and emergent phenomena.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Meta-Learning - Pattern Recognition", "Skills - Interdisciplinary 
       <li>Feedback loops and causality</li>
       <li>From parts to whole: emergence</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔗 Interdisciplinary Collaboration</h2>
     <p>Connectomics brings together biology, computation, engineering, ethics, and more. Learn to integrate methods and mindsets.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Meta-Learning - Pattern Recognition", "Skills - Interdisciplinary 
       <li>Cross-disciplinary team science</li>
       <li>Case studies in connectomics and beyond</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🔄 Holistic Approaches to Data</h2>
     <p>Apply systems concepts to data interpretation and hypothesis generation in connectomics.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Meta-Learning - Pattern Recognition", "Skills - Interdisciplinary 
       <li>Integrating functional and structural data</li>
       <li>Pattern detection across scales</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Systems frameworks, disciplinary methods</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Meta-Learning - Pattern Recognition", "Skills - Interdisciplinary 
       <li><strong>Character:</strong> Openness to other perspectives</li>
       <li><strong>Meta-Learning:</strong> Linking frameworks across domains</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Meadows, 2008. <em>Thinking in Systems</em></li>
       <li>NASEM, 2005. <em>Facilitating Interdisciplinary Research</em></li>
       <li>Colab: "Systems Map Generator for Connectomics"</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Create a system map for a neuroscience problem</li>
       <li>Identify disciplines contributing to a connectomics challenge</li>
       <li>Write a reflection on how systems thinking affects your analysis</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>

--- a/modules/module25.md
+++ b/modules/module25.md
@@ -28,7 +28,8 @@ ccr_focus: \["Meta-Learning - Portfolio Thinking", "Skills - Scientific Storytel
     </div>
   </div>
 
-  <section class="section">
+  <div class="cards-grid module-cards">
+<div class="card module-card">
     <h2>🌟 Building a Showcase Portfolio</h2>
     <p>Compile artifacts, reflections, and evidence from your journey to demonstrate skill mastery and your scientific growth.</p>
     <ul>
@@ -36,9 +37,9 @@ ccr_focus: \["Meta-Learning - Portfolio Thinking", "Skills - Scientific Storytel
       <li>Designing layout and narrative flow</li>
       <li>Curating for clarity and impact</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📖 Reflective Practice</h2>
     <p>Make sense of your growth as a researcher by documenting lessons learned, shifts in understanding, and future goals.</p>
     <ul>
@@ -46,9 +47,9 @@ ccr_focus: \["Meta-Learning - Portfolio Thinking", "Skills - Scientific Storytel
       <li>Voice and tone in self-narrative</li>
       <li>Connecting personal story to scientific progress</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🖋️ Presentation and Polish</h2>
     <p>Make your final product readable, compelling, and professional—ready for applications, networking, or sharing with peers.</p>
     <ul>
@@ -56,9 +57,9 @@ ccr_focus: \["Meta-Learning - Portfolio Thinking", "Skills - Scientific Storytel
       <li>Formatting and accessibility</li>
       <li>Optional video or oral presentation of portfolio</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>🌟 COMPASS Integration</h2>
     <ul>
       <li><strong>Knowledge:</strong> Milestones and module integration</li>
@@ -66,23 +67,24 @@ ccr_focus: \["Meta-Learning - Portfolio Thinking", "Skills - Scientific Storytel
       <li><strong>Character:</strong> Reflectiveness, intentionality</li>
       <li><strong>Meta-Learning:</strong> Learning how to showcase learning</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>📚 References & Resources</h2>
     <ul>
       <li>Colab: "Capstone Portfolio Template"</li>
       <li>Brown, 2020. <em>Designing a Personal Learning Portfolio</em></li>
       <li>GitHub Pages + Notion as hosting platforms</li>
     </ul>
-  </section>
+  </div>
 
-  <section class="section">
+  <div class="card module-card">
     <h2>✅ Assessment</h2>
     <ul>
       <li>Submit digital capstone portfolio with at least 10 linked artifacts</li>
       <li>Include written and/or video reflection</li>
       <li>Peer feedback and revision before final submission</li>
     </ul>
-  </section>
+  </div>
+</div>
 </div>


### PR DESCRIPTION
## Summary
- drop module matrix from module layout so each module page stands alone
- switch all modules to cards layout
- add mission tagline on models page and hide first tagline line in list

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_688842fa2b34832dbc74f9a4af126f51