### PR TITLE
Fix MouseConnects dataset page permalink

### DIFF
--- a/datasets/mouseconnects.md
+++ b/datasets/mouseconnects.md
@@ -1,6 +1,7 @@
 ---
 layout: dataset
 title: "MouseConnects Dataset - Complete Hippocampal Connectome"
+permalink: /datasets/mouseconnects/
 ---
 <style>
 


### PR DESCRIPTION
## Summary
- ensure MouseConnects dataset page uses clean permalink

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d4a2d92c832d953902a471cab90e