### PR TITLE
Add BossDB notebook links

### DIFF
--- a/modules/module02.md
+++ b/modules/module02.md
@@ -67,6 +67,8 @@ ccr_focus:
       <li><strong>Zheng et al., 2018</strong>, Nature – FlyWire / FAFB EM volume of adult fly brain</li>
       <li><strong>MICrONS dataset release</strong>, 2021 – V1 Layer 2/3 mouse volume</li>
       <li><a href="https://bossdb.org">Allen Institute / BossDB</a></li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Five-Minute-Jump-Start.ipynb">Five-Minute Jump Start</a></li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/More-Advanced-Get-Started-Downloading-Data-with-Intern.ipynb">Advanced Data Downloading</a></li>
     </ul>
   </div>
 

--- a/modules/module04.md
+++ b/modules/module04.md
@@ -76,6 +76,7 @@ ccr_focus: \["Knowledge - Neuroscience Foundations", "Skills - Analytical Thinki
       <li>Neuroanatomy Videos: <a href="https://www.youtube.com/@NeuroscientificallyChallenged">Neuroscientifically Challenged</a></li>
       <li>Human Connectome Project: <a href="https://www.humanconnectome.org">humanconnectome.org</a></li>
       <li>FlyWire Neuroglancer Viewer: <a href="https://flywire.ai">flywire.ai</a></li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/IARPA-MICrONS-Pinky100.ipynb">MICrONS Pinky100 Walkthrough</a></li>
     </ul>
   </div>
 

--- a/modules/module05.md
+++ b/modules/module05.md
@@ -77,6 +77,7 @@ ccr_focus:
       <li>Januszewski et al., 2018. <em>High-precision automated reconstruction of neurons with flood-filling networks</em>. Nature Methods.</li>
       <li>Neuroglancer: <a href="https://github.com/google/neuroglancer">github.com/google/neuroglancer</a></li>
       <li>SNEMI3D Benchmark: <a href="https://cremi.org">cremi.org</a></li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Uploading-Image-Stacks.ipynb">Uploading Image Stacks</a></li>
     </ul>
   </div>
 

--- a/modules/module08.md
+++ b/modules/module08.md
@@ -77,6 +77,7 @@ ccr_focus:
       <li>Ghasemi & Zahediasl, 2012. <em>Normality tests for statistical analysis: A guide for non-statisticians</em>. Int J Endocrinol Metab.</li>
       <li>Field et al., 2012. <em>Discovering Statistics Using R</em>. Sage.</li>
       <li>Colab: "Statistical Tests in Python with SciPy"</li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Accessing-Lower-Resolution-Versions-Of-Data-From-BossDB.ipynb">Accessing Lower Resolution Data</a></li>
     </ul>
   </div>
 

--- a/modules/module09.md
+++ b/modules/module09.md
@@ -76,6 +76,7 @@ ccr_focus: \["Knowledge - Network Science", "Skills - Graph Analysis"]
       <li>Rubinov & Sporns, 2010. <em>Complex network measures of brain connectivity</em>. NeuroImage.</li>
       <li>Colab: <a href="https://colab.research.google.com/">Interactive Graph Metrics in Python</a></li>
       <li>Gephi: <a href="https://gephi.org">gephi.org</a></li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/Querying-Connectomes-With-NeuPrint.ipynb">Querying Connectomes with NeuPrint</a></li>
     </ul>
   </div>
 

--- a/modules/module11.md
+++ b/modules/module11.md
@@ -75,6 +75,7 @@ ccr_focus: \["Knowledge - Machine Learning", "Skills - Model Evaluation"]
       <li>Januszewski et al., 2018. <em>Flood-filling networks</em>. Nature Methods.</li>
       <li>Goodfellow et al., <em>Deep Learning</em>, MIT Press.</li>
       <li>Colab: "Intro to CNNs for EM Segmentation"</li>
+      <li><a href="https://bossdb.org">BossDB</a> Cookbook: <a href="https://github.com/aplbrain/bossdb_cookbook/blob/main/notebooks/BossDB-Dataset-Classes-for-Pytorch-DataLoaders.ipynb">BossDB Dataset Classes for PyTorch</a></li>
     </ul>
   </div>
 


### PR DESCRIPTION
## Summary
- link BossDB cookbook notebooks in several modules
- cross-link to bossdb.org

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888e2275bec832dbdac6b45cf2a51ee