### PR TITLE
Remove duplicate tagline card from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,16 +30,6 @@ description: "A curriculum and mentorship platform for nanoscale connectomics di
             </div>
         </section>
 
-        <!-- Program Tagline -->
-        <section class="section section-highlight">
-            <div class="cards-grid">
-                <div class="card text-center" style="max-width: 700px; margin: 0 auto;">
-                    {% for line in site.tagline_lines %}
-                    <p class="card-description">{{ line }}</p>
-                    {% endfor %}
-                </div>
-            </div>
-        </section>
 
         <!-- Main Content -->
         <div class="main-content">


### PR DESCRIPTION
## Summary
- remove the tagline card from the homepage layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888f0fab160832dab226d7374fa7e5f