### PR TITLE
Improve banner layout and smaller header fonts

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -27,10 +27,14 @@ body {
   display: block;
 }
 
+.site-banner {
+  margin-bottom: 0.5rem;
+}
+
 .navbar {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 1rem 2rem;
+  padding: 0.75rem 1.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -57,7 +61,7 @@ body {
 }
 
 .logo {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
   color: var(--neural-blue);
   text-decoration: none;
@@ -81,6 +85,7 @@ body {
   padding: 0.5rem 0.75rem;
   border-radius: 4px;
   font-weight: 600;
+  font-size: 0.9rem;
 }
 
 .nav-link:hover,


### PR DESCRIPTION
## Summary
- space banner away from navbar in `site-styles.css`
- shrink the logo and navigation font sizes
- reduce navbar padding

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6888f45b2124832d95ec76051c743877