### PR TITLE
Reduce top padding on datasets page

### DIFF
--- a/assets/css/site-styles.css
+++ b/assets/css/site-styles.css
@@ -266,6 +266,11 @@ body {
   margin: 2rem auto;
   max-width: 1200px;
 }
+.section-compact {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  margin: 1rem auto;
+}
 .section-highlight {
   background: var(--brain-gray);
   padding: 3rem;
@@ -740,6 +745,10 @@ footer {
 .hero-spaced {
   margin: 0 -2rem 4rem -2rem;
   padding: 3rem 2rem;
+}
+.hero-compact {
+  padding: 1.5rem 2rem;
+  margin-bottom: 1.5rem;
 }
 .hero-rounded {
   border-radius: 12px;

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -5,13 +5,13 @@ description: "Explore curated connectomics datasets from landmark studies includ
 ---
 
 <div class="main-content">
-  <div class="hero hero-spaced">
+  <div class="hero hero-spaced hero-compact">
     <div class="hero-content">
       <h1 class="hero-title-impact">Connectomics Datasets</h1>
     </div>
   </div>
 
-  <section class="section">
+  <section class="section section-compact">
     <div class="card-gray text-center" style="max-width: 700px; margin: 0 auto;">
       <p><strong>Learn with real scientific data from groundbreaking research.</strong></p>
       <p>Explore carefully curated datasets from landmark connectomics studies. Each dataset represents years of cutting-edge research and offers unique insights into neural circuit organization.</p>


### PR DESCRIPTION
## Summary
- add `.hero-compact` and `.section-compact` utility classes
- tighten spacing in datasets intro

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68890237a280832da03d3aa3c91d4017