### PR TITLE
Fix MouseConnects dataset link on dataset index

### DIFF
--- a/datasets/index.md
+++ b/datasets/index.md
@@ -22,7 +22,7 @@ description: "Explore curated connectomics datasets from landmark studies includ
     <h2>MouseConnects: HI-MC Spotlight</h2>
     <div class="dataset-card featured spotlight">
       <div class="dataset-header">
-        <h3><span class="dataset-icon">🚀</span> <a href="{{ '/tools/himc' | relative_url }}">MouseConnects: High-throughput Imaging for Mouse Connectomics (HI-MC)</a></h3>
+        <h3><span class="dataset-icon">🚀</span> <a href="{{ '/datasets/mouseconnectome' | relative_url }}">MouseConnects: High-throughput Imaging for Mouse Connectomics (HI-MC)</a></h3>
         <div class="dataset-meta">
           <span class="dataset-type">Hippocampus</span>
           <span class="dataset-status">In Progress (2023-2028)</span>


### PR DESCRIPTION
## Summary
- fix MouseConnects header link in datasets index so it points to the dataset overview page

## Testing
- `bundle --version`

------
https://chatgpt.com/codex/tasks/task_e_688915663774832dbbb1ca05e57fa7d5