### PR TITLE
Add KB integration for lineage data and graph syncing

### DIFF
--- a/scripts/bibliometrics/build_lineage_data.py
+++ b/scripts/bibliometrics/build_lineage_data.py
@@ -2,24 +2,51 @@
 """
 Build citation lineage data for ancestry visualization.
 
-Processes corpus_kcore_25.json to create:
-1. Nodes with generation/level info
-2. Links based on actual citation relationships
-3. Topological sort respecting citation dependencies
+Loads papers from one of three sources (in priority order):
+1. Pre-built lineage_data.json from connectome-kb (copy directly)
+2. corpus_canonical.json from connectome-kb (filter tier=="included", recompute)
+3. Legacy corpus_kcore_25.json (backward compatibility)
 
 Output: assets/analysis/lineage_data.json
 """
 import json
+import shutil
 from pathlib import Path
 from collections import defaultdict, deque
 
-OUTPUT_DIR = Path("output")
-ASSETS_DIR = Path("../../assets/analysis")
+from config import KB_OUTPUTS_PATH, OUTPUT_DIR, ASSETS_DIR
+
 
 def load_corpus():
-    """Load core papers with citation data."""
-    with open(OUTPUT_DIR / "corpus_kcore_25.json") as f:
+    """
+    Load core papers with citation data.
+
+    Returns dict of {openalex_id: paper}, or None if pre-built lineage
+    was copied directly from KB (no recompute needed).
+    """
+    # Tier 1: KB already built lineage_data.json — copy and skip recompute
+    kb_lineage = KB_OUTPUTS_PATH / "lineage_data.json"
+    if kb_lineage.exists():
+        ASSETS_DIR.mkdir(parents=True, exist_ok=True)
+        out = ASSETS_DIR / "lineage_data.json"
+        shutil.copy(kb_lineage, out)
+        print(f"  Copied pre-built lineage from KB: {kb_lineage}")
+        return None
+
+    # Tier 2: KB corpus_canonical.json — load and filter by tier
+    kb_corpus = KB_OUTPUTS_PATH / "corpus_canonical.json"
+    if kb_corpus.exists():
+        with open(kb_corpus) as f:
+            all_papers = json.load(f)
+        papers = [p for p in all_papers if p.get("tier") == "included"]
+        print(f"  Loaded {len(papers)} included papers from KB corpus_canonical.json")
+        return {p["openalex_id"]: p for p in papers}
+
+    # Tier 3: Legacy fallback
+    legacy = OUTPUT_DIR / "corpus_kcore_25.json"
+    with open(legacy) as f:
         papers = json.load(f)
+    print(f"  Loaded {len(papers)} papers from legacy corpus_kcore_25.json")
     return {p['openalex_id']: p for p in papers}
 
 def build_citation_graph(papers):
@@ -149,7 +176,13 @@ def build_lineage_data(papers, graph, in_degree, out_degree, generations):
 def main():
     print("Loading corpus...")
     papers = load_corpus()
-    print(f"  Loaded {len(papers)} core papers (k ≥ 25)")
+
+    # If load_corpus returned None, lineage was already copied from KB
+    if papers is None:
+        print("Done (used pre-built KB lineage).")
+        return
+
+    print(f"  {len(papers)} papers loaded")
 
     print("Building citation graph...")
     graph, in_degree, out_degree = build_citation_graph(papers)
@@ -172,7 +205,7 @@ def main():
         'metadata': {
             'total_papers': len(nodes),
             'total_citations': len(links),
-            'generation_count': max(generations.values()) + 1,
+            'generation_count': max(generations.values()) + 1 if generations else 0,
             'year_range': [
                 min(p['year'] for p in papers.values()),
                 max(p['year'] for p in papers.values()),
@@ -181,6 +214,7 @@ def main():
     }
 
     # Save to assets directory for use in visualization
+    ASSETS_DIR.mkdir(parents=True, exist_ok=True)
     output_path = ASSETS_DIR / "lineage_data.json"
     print(f"\nSaving to {output_path}...")
     with open(output_path, 'w') as f:

--- a/scripts/bibliometrics/config.py
+++ b/scripts/bibliometrics/config.py
@@ -7,6 +7,7 @@ Change these and re-run — the pipeline reuses cached API responses.
 Scope: Nanoscale / synaptic-resolution connectomics (EM, barcoding, ExM, X-ray).
 Excludes macro-connectomics (dMRI/fMRI) unless bridging to nanoscale.
 """
+import os
 from pathlib import Path
 
 # ── Paths ──────────────────────────────────────────────────────────────
@@ -15,7 +16,15 @@ REPO_ROOT = BASE_DIR.parent.parent
 SEED_PAPERS_DIR = REPO_ROOT / "_data" / "expert_seed_papers"
 JOURNAL_PAPERS_YML = REPO_ROOT / "_data" / "journal_papers.yml"
 CACHE_DIR = BASE_DIR / "cache"
-OUTPUT_DIR = BASE_DIR / "output"
+OUTPUT_DIR = BASE_DIR / "outputs"
+GRAPHS_DIR = OUTPUT_DIR / "graphs"
+ASSETS_DIR = REPO_ROOT / "assets" / "analysis"
+
+# Path to connectome-kb website exports (set via env var or default to sibling repo)
+KB_OUTPUTS_PATH = Path(os.environ.get(
+    "KB_OUTPUTS_PATH",
+    str(REPO_ROOT.parent / "connectome-kb" / "outputs" / "website"),
+))
 
 # ── OpenAlex API ───────────────────────────────────────────────────────
 OPENALEX_BASE = "https://api.openalex.org"

--- a/scripts/sync_from_kb.sh
+++ b/scripts/sync_from_kb.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Sync connectome-kb website outputs into neurotrailblazers assets.
+# Run from the neurotrailblazers repo root.
+#
+# Usage:
+#   bash scripts/sync_from_kb.sh
+#   KB_OUTPUTS_PATH=/custom/path bash scripts/sync_from_kb.sh
+
+set -e
+
+KB_DIR="${KB_OUTPUTS_PATH:-../connectome-kb/outputs/website}"
+NT_ASSETS="assets/analysis"
+
+if [ ! -d "$KB_DIR" ]; then
+    echo "Error: KB outputs not found at $KB_DIR"
+    echo "Run the connectome-kb pipeline first, or set KB_OUTPUTS_PATH."
+    exit 1
+fi
+
+mkdir -p "$NT_ASSETS/graphs"
+
+cp "$KB_DIR/graphs/citation_graph.json" "$NT_ASSETS/graphs/"
+cp "$KB_DIR/graphs/cocitation_graph.json" "$NT_ASSETS/graphs/"
+cp "$KB_DIR/graphs/coupling_graph.json" "$NT_ASSETS/graphs/"
+cp "$KB_DIR/graphs/coauthorship_graph.json" "$NT_ASSETS/graphs/"
+
+cp "$KB_DIR/paper_rankings.json" "$NT_ASSETS/"
+cp "$KB_DIR/author_rankings.json" "$NT_ASSETS/"
+cp "$KB_DIR/communities.json" "$NT_ASSETS/"
+cp "$KB_DIR/lineage_data.json" "$NT_ASSETS/"
+
+echo "Synced KB outputs from $KB_DIR → $NT_ASSETS"
+echo "  $(ls "$NT_ASSETS/graphs/" | wc -l) graph files"
+echo "  $(ls "$NT_ASSETS"/*.json | wc -l) ranking/metadata files"


### PR DESCRIPTION
## Summary
Integrate connectome-kb outputs into neurotrailblazers by adding support for loading pre-built lineage data and other analysis artifacts directly from the KB pipeline, with fallback to legacy local computation.

## Key Changes

- **Tiered data loading in `build_lineage_data.py`**: Implemented a three-tier priority system:
  1. Use pre-built `lineage_data.json` from KB (copy directly, skip recomputation)
  2. Load `corpus_canonical.json` from KB and filter by `tier=="included"` (recompute if needed)
  3. Fall back to legacy `corpus_kcore_25.json` for backward compatibility

- **New sync script `sync_from_kb.sh`**: Added bash script to copy KB website outputs (graphs, rankings, metadata) into neurotrailblazers assets directory, with configurable KB path via `KB_OUTPUTS_PATH` environment variable

- **Config updates in `config.py`**:
  - Added `KB_OUTPUTS_PATH` configuration with environment variable support (defaults to sibling `connectome-kb/outputs/website`)
  - Renamed `OUTPUT_DIR` from `output` to `outputs` for consistency
  - Added `GRAPHS_DIR` and `ASSETS_DIR` path definitions
  - Exported these paths for use across scripts

- **Robustness improvements**:
  - Added `shutil.copy()` import for file operations
  - Added directory creation with `mkdir(parents=True, exist_ok=True)` before writing outputs
  - Fixed edge case: handle empty generations dict when computing generation count

## Implementation Details

The tiered loading approach allows the pipeline to gracefully degrade: if KB outputs are available, use them directly; otherwise, recompute from canonical corpus; finally, fall back to legacy data. This maintains backward compatibility while enabling seamless integration with the KB pipeline when available.

The `KB_OUTPUTS_PATH` environment variable allows flexible deployment scenarios (local development, CI/CD, different KB repository locations).

https://claude.ai/code/session_01MmVEhhm13c51aT8vq8DY4G