### PR TITLE
Copy-edit pass and figure overflow fixes for the Neuronauts story

### DIFF
--- a/neuronauts/index.html
+++ b/neuronauts/index.html
@@ -813,8 +813,8 @@ permalink: /neuronauts/
           <g transform="translate(352 100)">
             <circle r="15" fill="#fff" stroke="#0891b2" stroke-width="4"/>
             <text y="5" font-size="13" font-weight="800" fill="#0891b2">3</text>
-            <text y="-28" font-size="13" font-weight="700" fill="#0891b2">Image</text>
-            <text y="-13.5" font-size="10.5" fill="#64748b" font-family="'Source Sans 3',sans-serif">61 beams, petabytes</text>
+            <text y="-40" font-size="13" font-weight="700" fill="#0891b2">Image</text>
+            <text y="-25.5" font-size="10.5" fill="#64748b" font-family="'Source Sans 3',sans-serif">61 beams, petabytes</text>
           </g>
           <g transform="translate(464 148)">
             <circle r="15" fill="#fff" stroke="#4f46e5" stroke-width="4"/>
@@ -825,8 +825,8 @@ permalink: /neuronauts/
           <g transform="translate(576 104)">
             <circle r="15" fill="#fff" stroke="#ea580c" stroke-width="4"/>
             <text y="5" font-size="13" font-weight="800" fill="#ea580c">5</text>
-            <text y="-28" font-size="13" font-weight="700" fill="#ea580c">Segment</text>
-            <text y="-13.5" font-size="10.5" fill="#64748b" font-family="'Source Sans 3',sans-serif">AI colors every cell</text>
+            <text y="-40" font-size="13" font-weight="700" fill="#ea580c">Segment</text>
+            <text y="-25.5" font-size="10.5" fill="#64748b" font-family="'Source Sans 3',sans-serif">AI colors every cell</text>
           </g>
           <g transform="translate(688 145)">
             <circle r="15" fill="#fff" stroke="#be185d" stroke-width="4"/>
@@ -853,7 +853,7 @@ permalink: /neuronauts/
     <div class="nn-act-head"><span class="nn-leg-badge">Briefing</span><h2>The mission briefing: why go at all?</h2></div>
     <p class="nn-guide">Your guide: <strong>Captain Cortex</strong> — every expedition starts with the case for going.</p>
     <p class="nn-lede">Before the crew suits up, a fair challenge: neuroscience already has brain maps. MRI scanners map whole human brains in an afternoon — the Human Connectome Project charted the highways connecting brain regions in over a thousand people <a class="srcref" href="#src-37" style="color:#92400e;font-weight:700;text-decoration:none">[37]</a>. And microscopists have made gorgeous portraits of individual neurons since Santiago Ramón y Cajal's ink drawings in 1900. So why mount a whole expedition?</p>
-    <p>Because between those two views lies a gap — and the gap is where thinking happens. MRI sees bundles of <em>millions</em> of wires as one blurry highway; a single-cell portrait shows you one tree and no forest. Neither can tell you which neuron talks to which. The circuit — the actual computing machinery, thousands of specific cells wired in specific patterns — sits squarely in the missing middle. Filling that gap is the founding argument of this field, and it comes with four reasons worth knowing, adapted here from the "Why Connectomics?" lectures that this site's training program grew out of <a class="srcref" href="#src-35" style="color:#92400e;font-weight:700;text-decoration:none">[35]</a>:</p>
+    <p>Because between those two views lies a gap — and the gap is where thinking happens. MRI sees bundles of <em>millions</em> of wires as one blurry highway; a single-cell portrait shows you one tree and no forest. Neither can tell you which neuron talks to which. The circuit — the actual computing machinery, thousands of specific cells wired in specific patterns — sits squarely in the missing middle. Filling that gap is the founding argument of this field, and it comes with four reasons worth knowing, adapted from the "Why Connectomics?" lecture notes this program grew out of <a class="srcref" href="#src-35" style="color:#92400e;font-weight:700;text-decoration:none">[35]</a>:</p>
     <div class="nn-why-grid">
       <div class="nn-why-card">
         <h4>1. The gap is real</h4>
@@ -869,11 +869,11 @@ permalink: /neuronauts/
       </div>
       <div class="nn-why-card">
         <h4>4. The existence proof</h4>
-        <p>As the lecture puts it: humans are good at stuff. Somewhere in that wiring is a working design for general intelligence that runs on about 20 watts. It exists; therefore it can be studied. <a class="srcref" href="#src-35" style="color:#92400e;font-weight:700;text-decoration:none">[35]</a> <a class="srcref" href="#src-30" style="color:#92400e;font-weight:700;text-decoration:none">[30]</a></p>
+        <p>As the lecture notes put it: humans are good at stuff. Somewhere in that wiring is a working design for general intelligence that runs on about 20 watts. It exists; therefore it can be studied. <a class="srcref" href="#src-35" style="color:#92400e;font-weight:700;text-decoration:none">[35]</a> <a class="srcref" href="#src-30" style="color:#92400e;font-weight:700;text-decoration:none">[30]</a></p>
       </div>
     </div>
     <h3 style="margin-top:2rem">The data mountain</h3>
-    <p>One more thing the briefing must be honest about: the climb. Here is the classic back-of-envelope ladder of what wire-level imaging costs in data, animal by animal — order-of-magnitude estimates that connectomics courses have used for years to explain why each rung demands new machines <a class="srcref" href="#src-35" style="color:#92400e;font-weight:700;text-decoration:none">[35]</a>. (Real modern datasets land in the same territory: the fly volume came to roughly a hundred terabytes, and a single cubic millimeter of cortex to 1.4–2 petabytes <a class="srcref" href="#src-10" style="color:#92400e;font-weight:700;text-decoration:none">[10]</a> <a class="srcref" href="#src-17" style="color:#92400e;font-weight:700;text-decoration:none">[17]</a> <a class="srcref" href="#src-18" style="color:#92400e;font-weight:700;text-decoration:none">[18]</a>.)</p>
+    <p>One more thing the briefing must be honest about: the climb. Here is the classic back-of-envelope ladder of what wire-level imaging costs in data, animal by animal — order-of-magnitude estimates these lecture notes have used for years to explain why each rung demands new machines <a class="srcref" href="#src-35" style="color:#92400e;font-weight:700;text-decoration:none">[35]</a>. (Real modern datasets land in the same territory: the fly volume came to roughly a hundred terabytes, and a single cubic millimeter of cortex to 1.4–2 petabytes <a class="srcref" href="#src-10" style="color:#92400e;font-weight:700;text-decoration:none">[10]</a> <a class="srcref" href="#src-17" style="color:#92400e;font-weight:700;text-decoration:none">[17]</a> <a class="srcref" href="#src-18" style="color:#92400e;font-weight:700;text-decoration:none">[18]</a>.)</p>
     <div class="nn-ladder" role="list" aria-label="Data required to image each animal's brain at wire-level resolution">
       <div class="nn-ladder-row" role="listitem">
         <span class="nn-ladder-animal">Worm</span>
@@ -921,13 +921,13 @@ permalink: /neuronauts/
         <g transform="translate(160 205)">
           <rect x="-18" y="0" width="36" height="45" rx="6" fill="#c7d2fe" stroke="#4338ca" stroke-width="2"/>
           <rect x="-7" y="-12" width="14" height="14" rx="3" fill="#4338ca"/>
-          <text x="0" y="28" text-anchor="middle" font-size="11" font-weight="700" fill="#3730a3" font-family="'Source Sans 3',sans-serif">FIXATIVE</text>
+          <text x="0" y="-20" text-anchor="middle" font-size="11" font-weight="700" fill="#3730a3" font-family="'Source Sans 3',sans-serif">fixative</text>
         </g>
         <g transform="translate(240 205)">
           <rect x="-18" y="0" width="36" height="45" rx="6" fill="#fed7aa" stroke="#9a3412" stroke-width="2"/>
           <rect x="-7" y="-12" width="14" height="14" rx="3" fill="#9a3412"/>
-          <text x="0" y="22" text-anchor="middle" font-size="11" font-weight="800" fill="#7c2d12" font-family="'IBM Plex Mono',monospace">OsO₄</text>
-          <text x="0" y="36" text-anchor="middle" font-size="9" fill="#9a3412" font-family="'Source Sans 3',sans-serif">heavy metal</text>
+          <text x="0" y="26" text-anchor="middle" font-size="11" font-weight="800" fill="#7c2d12" font-family="'IBM Plex Mono',monospace">OsO₄</text>
+          <text x="0" y="-20" text-anchor="middle" font-size="11" font-weight="700" fill="#9a3412" font-family="'Source Sans 3',sans-serif">heavy metal</text>
         </g>
         <!-- amber block with brain inside -->
         <g transform="translate(450 195)">
@@ -964,7 +964,7 @@ permalink: /neuronauts/
       <ul>
         <li>Why heavy metals, why resin, and how modern volume EM sample preparation works, from fixation through embedding: the field's own methods primer. <a class="srcref" href="#src-5">[5]</a></li>
         <li>Uniform en-bloc staining of large tissue volumes — a named, solved engineering problem, not folklore (Hua, Laserstein &amp; Helmstaedter, 2015). <a class="srcref" href="#src-6">[6]</a></li>
-        <li>The stakes of this leg: the human cortex sample behind the H01 dataset was preserved within about an hour of surgery, because preservation quality caps everything downstream. <a class="srcref" href="#src-18">[18]</a></li>
+        <li>The stakes of this leg: the human cortex sample behind the H01 dataset was rapidly preserved after neurosurgery, because preservation quality caps everything downstream. <a class="srcref" href="#src-18">[18]</a></li>
       </ul>
     </div>
   </div>
@@ -1236,7 +1236,7 @@ permalink: /neuronauts/
     </div>
     <p class="nn-baton"><strong>The baton:</strong> a gray 3D photograph → a labeled world, where every voxel knows which neuron it belongs to.</p>
     <p class="nn-lede">Zoom into the aligned volume and you'll see the truth about brains: gray, tangled spaghetti in every direction. Beautiful — and unreadable. Leg 5 is where each strand of spaghetti gets its own color: this voxel belongs to neuron #4,271; that one to neuron #88,904. Scientists call it <strong>segmentation</strong>.</p>
-    <p>Humans did this by hand for decades, and the arithmetic was crushing. The very first connectome — the worm <em>C. elegans</em>, 302 neurons — took White, Southgate, Thomson, and Brenner on the order of fifteen years, tracing photographic prints with colored pencils <a class="srcref" href="#src-3" style="color:#92400e;font-weight:700;text-decoration:none">[3]</a>. At that pace, a cubic millimeter of cortex was simply out of the question — one careful estimate of the manual effort behind even small dense reconstructions ran to hundreds of thousands of human hours per cubic millimeter.</p>
+    <p>Humans did this by hand for decades, and the arithmetic was crushing. The very first connectome — the worm <em>C. elegans</em>, 302 neurons — took White, Southgate, Thomson, and Brenner on the order of fifteen years, tracing photographic prints with colored pencils <a class="srcref" href="#src-3" style="color:#92400e;font-weight:700;text-decoration:none">[3]</a>. Even with modern software, densely reconstructing 950 retinal neurons consumed more than twenty thousand hours of human annotation <a class="srcref" href="#src-24" style="color:#92400e;font-weight:700;text-decoration:none">[24]</a>. At that pace, a cubic millimeter of cortex — two hundred times as many cells — was simply out of the question.</p>
     <p>Then came deep learning. In 2018, Google and Max Planck researchers published <strong>flood-filling networks</strong> — neural networks that "pour" a color into one neuron and let it flow along the cell's shape, stopping at the membrane walls that the heavy-metal stain made visible back in Leg 1 <a class="srcref" href="#src-12" style="color:#92400e;font-weight:700;text-decoration:none">[12]</a>. (See how the relay works? A chemistry decision made months earlier is what the AI leans on now.) Machine segmentation is what made the modern flagship datasets possible at all: 139,255 neurons in a fly brain <a class="srcref" href="#src-14" style="color:#92400e;font-weight:700;text-decoration:none">[14]</a>, 200,000 cells and 523 million synapses in a cubic millimeter of mouse cortex <a class="srcref" href="#src-17" style="color:#92400e;font-weight:700;text-decoration:none">[17]</a> — with the synapses, too, detected automatically.</p>
     <div class="nn-notes">
       <h3>Dendra's field notes — the evidence</h3>
@@ -1373,7 +1373,7 @@ permalink: /neuronauts/
             <circle cx="-12" cy="-8" r="6" fill="#f472b6"/>
             <circle cx="14" cy="6" r="6" fill="#4ade80"/>
             <path d="M -7 -5 C 0 0 5 2 9 4" stroke="#e2e8f0" stroke-width="2.5" fill="none"/>
-            <text x="0" y="62" text-anchor="middle" font-size="12" fill="#a5f3fc" font-family="'Source Sans 3',sans-serif">who connects to whom — and why</text>
+            <text x="-20" y="78" text-anchor="middle" font-size="12" fill="#a5f3fc" font-family="'Source Sans 3',sans-serif">who connects to whom — and why</text>
           </g>
         </g>
         <!-- crew planting flag -->
@@ -1525,11 +1525,11 @@ permalink: /neuronauts/
             <rect x="24" y="14" width="22" height="16" rx="4" fill="#475569"/>
             <circle cx="27" cy="66" r="5" fill="#94a3b8"/><circle cx="43" cy="66" r="5" fill="#94a3b8"/>
             <path d="M 56 44 L 72 36 L 72 52 Z" fill="#a5f3fc" stroke="#0891b2" stroke-width="1.8"/>
-            <g transform="translate(72 58)">
-              <rect x="0" y="0" width="48" height="26" rx="5" fill="#fff" stroke="#dc2626" stroke-width="2"/>
-              <rect x="0" y="0" width="48" height="9" rx="5" fill="#dc2626"/>
-              <text x="24" y="7.5" text-anchor="middle" font-size="6" font-weight="700" fill="#fff" font-family="'Source Sans 3',sans-serif">HELLO my name is</text>
-              <text x="24" y="20" text-anchor="middle" font-size="8.5" font-weight="800" fill="#1f2937" font-family="'Plus Jakarta Sans',sans-serif">connectome</text>
+            <g transform="translate(64 60)">
+              <rect x="0" y="0" width="60" height="28" rx="5" fill="#fff" stroke="#dc2626" stroke-width="2"/>
+              <rect x="0" y="0" width="60" height="10" rx="5" fill="#dc2626"/>
+              <text x="30" y="7.5" text-anchor="middle" font-size="5.5" font-weight="700" fill="#fff" font-family="'Source Sans 3',sans-serif">HELLO my name is</text>
+              <text x="30" y="22" text-anchor="middle" font-size="9" font-weight="800" fill="#1f2937" font-family="'Plus Jakarta Sans',sans-serif">connectome</text>
             </g>
           </svg>
         </div>
@@ -1652,7 +1652,7 @@ permalink: /neuronauts/
               <circle cx="86" cy="26" r="5"/><circle cx="96" cy="44" r="5"/><circle cx="90" cy="64" r="5"/><circle cx="74" cy="80" r="5"/><circle cx="46" cy="82" r="5"/><circle cx="22" cy="78" r="5"/>
               <circle cx="108" cy="16" r="5"/><circle cx="112" cy="62" r="5"/><circle cx="106" cy="82" r="5"/><circle cx="14" cy="60" r="5"/><circle cx="10" cy="38" r="5"/>
             </g>
-            <text x="64" y="14" text-anchor="middle" font-size="11" font-weight="800" fill="#6d28d9" font-family="'Plus Jakarta Sans',sans-serif">11 teams · ~$150M</text>
+            <text x="64" y="14" text-anchor="middle" font-size="10" font-weight="800" fill="#6d28d9" font-family="'Plus Jakarta Sans',sans-serif">11 teams · ~$150M</text>
           </svg>
         </div>
       </div>
@@ -1675,7 +1675,7 @@ permalink: /neuronauts/
             <g transform="translate(94 44)">
               <path d="M -14 -8 L 0 -16 L 14 -8 L 14 10 L 0 18 L -14 10 Z" fill="#fbcfe8" stroke="#be185d" stroke-width="2"/>
               <path d="M -14 -8 L 0 0 L 14 -8 M 0 0 L 0 18" stroke="#be185d" stroke-width="1.6" fill="none"/>
-              <text x="0" y="34" text-anchor="middle" font-size="10.5" font-weight="700" fill="#9d174d" font-family="'Source Sans 3',sans-serif">human, 1 mm³</text>
+              <text x="-4" y="34" text-anchor="middle" font-size="9.5" font-weight="700" fill="#9d174d" font-family="'Source Sans 3',sans-serif">human, 1 mm³</text>
             </g>
           </svg>
         </div>
@@ -1709,12 +1709,12 @@ permalink: /neuronauts/
         <div class="nn-tl-art">
           <svg viewBox="0 0 128 100" role="img" aria-label="A mountain drawn in dashed outline, its summit flag not yet planted">
             <rect width="128" height="100" fill="#fff7ed"/>
-            <path d="M 10 88 L 52 30 L 74 56 L 96 18 L 122 88 Z" fill="none" stroke="#ea580c" stroke-width="2.5" stroke-dasharray="7 5" stroke-linejoin="round"/>
-            <g transform="translate(96 18)">
-              <line x1="0" y1="0" x2="0" y2="-13" stroke="#9a3412" stroke-width="2" stroke-dasharray="3 3"/>
-              <path d="M 0 -13 L 11 -9.5 L 0 -6 Z" fill="none" stroke="#ea580c" stroke-width="1.8" stroke-dasharray="3 3"/>
+            <path d="M 10 78 L 52 26 L 74 50 L 96 16 L 122 78 Z" fill="none" stroke="#ea580c" stroke-width="2.5" stroke-dasharray="7 5" stroke-linejoin="round"/>
+            <g transform="translate(96 16)">
+              <line x1="0" y1="0" x2="0" y2="-11" stroke="#9a3412" stroke-width="2" stroke-dasharray="3 3"/>
+              <path d="M 0 -11 L 10 -8 L 0 -5 Z" fill="none" stroke="#ea580c" stroke-width="1.8" stroke-dasharray="3 3"/>
             </g>
-            <text x="64" y="96" text-anchor="middle" font-size="10.5" font-weight="700" fill="#9a3412" font-family="'Source Sans 3',sans-serif">~500 mm³ to go</text>
+            <text x="64" y="94" text-anchor="middle" font-size="10.5" font-weight="700" fill="#9a3412" font-family="'Source Sans 3',sans-serif">~500 mm³ to go</text>
           </svg>
         </div>
       </div>


### PR DESCRIPTION
## Summary
A polish pass over `/neuronauts/`, targeting `main` directly.

**Copy edits (accuracy-first):**
- Replaced an uncited "hundreds of thousands of human hours" manual-effort estimate with the citable figure: 20,000+ annotation hours for the 950-neuron retina reconstruction [24], and derived the cubic-millimeter comparison from it
- Softened the H01 preservation-timing claim to "rapidly preserved after neurosurgery," which is what the paper supports
- Aligned the mission-briefing and data-mountain wording with the WGR lecture-notes credit ("lecture notes this program grew out of")

**Figure fixes (all text overflow or collisions, verified in Chromium at 2× before/after):**
- Streams route map: raised the Image and Segment station labels clear of the river
- Leg 1: moved the fixative and heavy-metal labels above their bottles instead of overflowing them
- Leg 7: moved the magnifier caption off its handle
- Timeline vignettes: rebuilt the 2004 "connectome" name tag so both lines fit, fitted the 2023 and 2024 captions inside their frames, and raised the summit vignette's mountain off its caption

## Validation
- Jekyll build clean; frontmatter, site-link, and anchor audits all pass
- Full-page mobile check at 390px: no horizontal overflow
- Every citation reference resolves; no source left uncited

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hPwm4rFqHfsfRHUfsQhgt

---
_Generated by [Claude Code](https://claude.ai/code/session_016hPwm4rFqHfsfRHUfsQhgt)_