### PR TITLE
Merge 17 duplicate paper versions and fix 2 dimension mis-tags

### DIFF
--- a/_data/journal_papers.yml
+++ b/_data/journal_papers.yml
@@ -2,11 +2,16 @@
 #
 # Generated from connectomics-survey's visible-core export
 # (source_artifact/neurotrailblazers_visible_core/). One collection
-# (1,074 papers), multiple views. Do not split this into a second
-# corpus alongside hand-authored teaching pages -- those pages are
-# curated deep-dives into a subset of this same collection.
+# (1,074 papers originally; 17 preprint/published duplicate pairs merged
+# and 2 dimension mis-tags corrected 2026-08-27, see scripts/corpus_issues.json),
+# multiple views. Do not split this into a second corpus alongside
+# hand-authored teaching pages -- those pages are curated deep-dives into
+# a subset of this same collection.
 #
 # Regenerate with: python3 scripts/sync_journal_papers.py <connectomics-survey-checkout>/source_artifact/neurotrailblazers_visible_core
+# NOTE: regenerating will REVERT the 2026-08-27 duplicate merges and field
+# fixes -- re-apply scripts/apply_duplicate_merges.py after any regeneration
+# until upstream fixes these bugs (see scripts/corpus_issues.json).
 papers:
 - id: abir-2026-2026-06-06-730367
   uuid: 10.64898/2026.06.06.730367
@@ -7140,8 +7145,8 @@ papers:
   role: methods
   inclusion_role: sota
   k_core: 7
-  in_degree: 0
-  out_degree: 8
+  in_degree: 1
+  out_degree: 7
   annotation_status: generated_from_pdf
   tags:
   - drosophila
@@ -7195,9 +7200,9 @@ papers:
     - id: takemura-2023-2023-06-05-543757
       title: A Connectome of the Male Drosophila Ventral Nerve Cord
       year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: eckstein-2020-j-cell-2024-03-016
       title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
       year: 2020
@@ -7210,7 +7215,12 @@ papers:
     - id: yoshikawa-2023-2023-11-19-567707
       title: Mechanosensory and command contributions to the Drosophila grooming sequence
       year: 2023
-    cited_by: []
+    cited_by:
+    - id: calleschuler-2026-elife-108044
+      title: A comprehensive mechanosensory connectome reveals a somatotopically organized neural circuit architecture controlling stimulus-aimed grooming of the Drosophila head
+      year: 2026
+  alt_dois:
+  - 10.1101/2024.12.17.628844
 - id: zenari-2026-4514fb42
   uuid: work_195db71f4514fb42
   work_id: work_195db71f4514fb42
@@ -8055,9 +8065,6 @@ papers:
     - id: holler-2019-s41586-020-03134-2
       title: Structure and function of a neocortical synapse
       year: 2019
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: lee-2016-nature17192
       title: Anatomy and function of an excitatory network in the visual cortex
       year: 2016
@@ -8551,8 +8558,8 @@ papers:
     - id: eichler-2017-141762
       title: The complete connectome of a learning and memory centre in an insect brain
       year: 2017
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: xu-2017-elife-25916
       title: Enhanced FIB-SEM systems for large-volume 3D imaging
@@ -9263,8 +9270,8 @@ papers:
   role: methods
   inclusion_role: sota
   k_core: 13
-  in_degree: 18
-  out_degree: 23
+  in_degree: 15
+  out_degree: 12
   annotation_status: generated_from_pdf
   tags:
   - mouse
@@ -9339,6 +9346,18 @@ papers:
     - id: schneidermizell-2015-elife-12059
       title: Quantitative neuroanatomy for connectomics in Drosophila
       year: 2015
+    - id: schneidermizell-2021-elife-73783
+      title: Structure and function of axo-axonic inhibition
+      year: 2021
+    - id: dorkenwald-2022-s41592-023-02059-8
+      title: Multi-layered maps of neuropil with segmentation-guided contrastive learning
+      year: 2022
+    - id: shapsoncoe-2021-2021-05-29-446289
+      title: A connectomic study of a petascale fragment of human cerebral cortex
+      year: 2021
+    - id: lee-2016-nature17192
+      title: Anatomy and function of an excitatory network in the visual cortex
+      year: 2016
     cited_by:
     - id: richter-2026-2026-07-09-737432
       title: Learning the wiring rules of a mammalian cortical column
@@ -9364,6 +9383,29 @@ papers:
     - id: wang-2026-2025-10-04-680445
       title: 'iBrAVE: a unified framework for 3D interactive and integrative analysis of brain atlas data across modalities and scales'
       year: 2026
+    - id: salova-2024-netn-a-00428
+      title: Combined topological and spatial constraints are required to capture the structure of neural connectomes
+      year: 2024
+    - id: troidl-2023-2022-12-09-519772
+      title: ViMO - Visual Analysis of Neuronal Connectivity Motifs
+      year: 2023
+    - id: lesser-2024-s41586-024-07600-z
+      title: Synaptic architecture of leg and wing premotor control networks in Drosophila
+      year: 2024
+    - id: gamlin-2023-2023-03-22-533857
+      title: 'Integrating EM and Patch-seq data: Synaptic connectivity and target specificity of predicted Sst transcriptomic types'
+      year: 2023
+    - id: pokorny-2024-2024-05-24-593860
+      title: A connectome manipulation framework for the systematic and reproducible study of structure–function relationships through simulations
+      year: 2024
+    - id: reimann-2024-bhae433
+      title: Specific inhibition and disinhibition in the higher-order structure of a cortical connectome
+      year: 2024
+    - id: patio-2023-elife-89297
+      title: Postsynaptic cell type and synaptic distance do not determine efficiency of monosynaptic rabies virus spread measured at synaptic resolution
+      year: 2023
+  alt_dois:
+  - 10.1101/2023.01.23.525290
 - id: shan-2025-2025-12-06-692615
   uuid: 10.64898/2025.12.06.692615
   work_id: work_82ff344c3a29691d
@@ -9468,9 +9510,9 @@ papers:
   reading_phase: 3_sota
   role: methods
   inclusion_role: sota
-  k_core: 12
+  k_core: 13
   in_degree: 11
-  out_degree: 17
+  out_degree: 13
   annotation_status: generated_from_pdf
   tags:
   - drosophila
@@ -9544,6 +9586,21 @@ papers:
     - id: valdesaleman-2020-j-neuron-2020-10-004
       title: Comparative Connectomics Reveals How Partner Identity, Location, and Activity Specify Synaptic Connectivity in Drosophila
       year: 2020
+    - id: takemura-2023-2023-06-05-543757
+      title: A Connectome of the Male Drosophila Ventral Nerve Cord
+      year: 2023
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
+      year: 2020
+    - id: cook-2019-s41586-019-1352-7
+      title: Whole-animal connectomes of both Caenorhabditis elegans sexes
+      year: 2019
+    - id: schlegel-2020-elife-66018
+      title: Information flow, cell types and stereotypy in a full olfactory connectome
+      year: 2020
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     cited_by:
     - id: cheong-2026-elife-96084
       title: Organization of circuits linking descending input to motor output in the Drosophila Male Adult Nerve Cord connectome
@@ -9563,6 +9620,23 @@ papers:
     - id: schnell-2026-j-tins-2025-12-005
       title: Flexible circuits for visually guided flight control in Drosophila.
       year: 2026
+    - id: schlegel-2024-s41586-024-07686-5
+      title: Whole-brain annotation and multi-connectome cell typing of Drosophila
+      year: 2024
+    - id: dorkenwald-2024-s41586-024-07558-y
+      title: Neuronal wiring diagram of an adult brain
+      year: 2024
+    - id: lesser-2024-s41586-024-07600-z
+      title: Synaptic architecture of leg and wing premotor control networks in Drosophila
+      year: 2024
+    - id: zdil-2026-s41467-026-72152-x
+      title: Centralized brain networks controlling antennal grooming coordination
+      year: 2026
+    - id: schretter-2024-s41586-024-08255-6
+      title: Social state alters vision using three circuit mechanisms in Drosophila
+      year: 2024
+  alt_dois:
+  - 10.1101/2024.06.04.596633
 - id: tastekin-2025-2025-08-25-671814
   uuid: 10.1101/2025.08.25.671814
   work_id: work_2a92ba160393c193
@@ -12667,9 +12741,9 @@ papers:
   reading_phase: 2_contemporary
   role: methods
   inclusion_role: contemporary
-  k_core: 11
+  k_core: 13
   in_degree: 3
-  out_degree: 14
+  out_degree: 12
   annotation_status: generated_from_pdf
   tags:
   - clem
@@ -12744,6 +12818,18 @@ papers:
     - id: fulton-2020-elife-63392
       title: Permeabilization-free en bloc immunohistochemistry for correlative microscopy
       year: 2020
+    - id: briggman-2011-nature09818
+      title: Wiring specificity in the direction-selectivity circuit of the retina
+      year: 2011
+    - id: shapsoncoe-2021-2021-05-29-446289
+      title: A connectomic study of a petascale fragment of human cerebral cortex
+      year: 2021
+    - id: bock-2011-nature09802
+      title: Network anatomy and in vivo physiology of visual cortical neurons
+      year: 2011
+    - id: lee-2016-nature17192
+      title: Anatomy and function of an excitatory network in the visual cortex
+      year: 2016
     cited_by:
     - id: tavakoli-2025-s41586-025-08985-1
       title: Light-microscopy-based connectomic reconstruction of mammalian brain tissue
@@ -12754,6 +12840,8 @@ papers:
     - id: lu-2026-s41467-026-72180-7
       title: Probing molecular diversity and ultrastructure of brain cells with fluorescent aptamers
       year: 2026
+  alt_dois:
+  - 10.21203/rs.3.rs-3121892/v1
 - id: he-2024-giae076
   uuid: 10.1093/gigascience/giae076
   work_id: work_55a637a99f2abc58
@@ -13180,9 +13268,9 @@ papers:
   reading_phase: 2_contemporary
   role: methods
   inclusion_role: contemporary
-  k_core: 11
-  in_degree: 17
-  out_degree: 3
+  k_core: 13
+  in_degree: 12
+  out_degree: 10
   annotation_status: generated_from_pdf
   tags:
   - drosophila
@@ -13239,6 +13327,27 @@ papers:
     - id: scheffer-2021-jeb-242740
       title: A connectome is not enough - what is still needed to understand the brain of Drosophila?
       year: 2021
+    - id: takemura-2013-nature12450
+      title: A visual motion detection circuit suggested by Drosophila connectomics
+      year: 2013
+    - id: dorkenwald-2020-s41592-021-01330-0
+      title: 'FlyWire: Online community for whole-brain connectomics'
+      year: 2020
+    - id: shapsoncoe-2021-2021-05-29-446289
+      title: A connectomic study of a petascale fragment of human cerebral cortex
+      year: 2021
+    - id: hulse-2020-2020-12-08-413955
+      title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
+      year: 2020
+    - id: svara-2022-s41592-022-01621-0
+      title: Automated synapse-level reconstruction of neural circuits in the larval zebrafish brain
+      year: 2022
+    - id: oh-2014-nature13186
+      title: A mesoscale connectome of the mouse brain
+      year: 2014
+    - id: motta-2018-science-aay3134
+      title: Dense connectomic reconstruction in layer 4 of the somatosensory cortex
+      year: 2018
     cited_by:
     - id: pospisil-2024-s41586-024-07982-0
       title: The fly connectome reveals a path to the effectome
@@ -13264,6 +13373,17 @@ papers:
     - id: beiran-2024-s41593-025-02080-4
       title: Prediction of neural activity in connectome-constrained recurrent networks
       year: 2024
+    - id: eckstein-2020-j-cell-2024-03-016
+      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
+      year: 2020
+    - id: bae-2021-s41586-025-08790-w
+      title: Functional connectomics spanning multiple areas of mouse visual cortex
+      year: 2021
+    - id: joyce-2023-2023-10-20-563359
+      title: A Novel Semi-automated Proofreading and Mesh Error Detection Pipeline for Neuron Extension
+      year: 2023
+  alt_dois:
+  - 10.1101/2023.03.11.532232
 - id: latifi-2024-j-tins-2024-01-003
   uuid: 10.1016/j.tins.2024.01.003
   work_id: work_24db0b13f227c74f
@@ -13471,12 +13591,12 @@ papers:
     - id: li-2020-elife-62576
       title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: barnes-2020-journal-pone-0266064
       title: Synaptic counts approximate synaptic contact area in Drosophila
       year: 2020
@@ -13804,8 +13924,8 @@ papers:
   role: methods
   inclusion_role: contemporary
   k_core: 12
-  in_degree: 2
-  out_degree: 13
+  in_degree: 0
+  out_degree: 9
   annotation_status: generated_from_pdf
   tags:
   - waspsyn
@@ -13878,7 +13998,12 @@ papers:
     - id: bae-2021-s41586-025-08790-w
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
+    - id: plaza-2014-j-conb-2014-01-019
+      title: Toward large-scale connectome reconstructions.
+      year: 2014
     cited_by: []
+  alt_dois:
+  - 10.48550/arxiv.2302.00545
 - id: lin-2024-s41586-024-07968-y
   uuid: 10.1038/s41586-024-07968-y
   work_id: work_d585630845101835
@@ -14350,9 +14475,9 @@ papers:
     - id: funke-2019-tpami-2018-2835450
       title: Large Scale Image Segmentation with Structured Loss Based Deep Learning for Connectome Reconstruction
       year: 2019
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     cited_by: []
 - id: marin-2024-2023-06-05-543407
   uuid: 10.1101/2023.06.05.543407
@@ -14428,9 +14553,9 @@ papers:
     - id: takemura-2023-2023-06-05-543757
       title: A Connectome of the Male Drosophila Ventral Nerve Cord
       year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: dorkenwald-2024-s41586-024-07558-y
       title: Neuronal wiring diagram of an adult brain
       year: 2024
@@ -15936,9 +16061,9 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: bae-2021-s41586-025-08790-w
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
@@ -16347,9 +16472,9 @@ papers:
     - id: shapsoncoe-2021-2021-05-29-446289
       title: A connectomic study of a petascale fragment of human cerebral cortex
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: motta-2018-science-aay3134
       title: Dense connectomic reconstruction in layer 4 of the somatosensory cortex
       year: 2018
@@ -16607,9 +16732,9 @@ papers:
     - id: shapsoncoe-2021-2021-05-29-446289
       title: A connectomic study of a petascale fragment of human cerebral cortex
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
@@ -17128,9 +17253,9 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: dorkenwald-2024-s41586-024-07558-y
       title: Neuronal wiring diagram of an adult brain
       year: 2024
@@ -17528,8 +17653,8 @@ papers:
   role: methods
   inclusion_role: contemporary
   k_core: 9
-  in_degree: 8
-  out_degree: 8
+  in_degree: 10
+  out_degree: 9
   annotation_status: generated_from_pdf
   tags:
   - drosophila
@@ -17602,6 +17727,9 @@ papers:
     - id: huang-2018-fninf-2018-00099
       title: A Single-Cell Level and Connectome-Derived Computational Model of the Drosophila Brain
       year: 2018
+    - id: meinertzhagen-2018-jeb-164954
+      title: Of what use is connectomics? A personal perspective on the Drosophila connectome
+      year: 2018
     cited_by:
     - id: dorkenwald-2024-s41586-024-07558-y
       title: Neuronal wiring diagram of an adult brain
@@ -17627,6 +17755,14 @@ papers:
     - id: wang-2026-84de41d1
       title: 'FLYNN: Robust Neural Network for Robot Navigation using Fly Brain Topology'
       year: 2026
+    - id: eckstein-2020-j-cell-2024-03-016
+      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
+      year: 2020
+    - id: joyce-2023-2023-10-20-563359
+      title: A Novel Semi-automated Proofreading and Mesh Error Detection Pipeline for Neuron Extension
+      year: 2023
+  alt_dois:
+  - 10.1101/2023.05.02.539144
 - id: shuai-2024-2023-09-15-557808
   uuid: 10.1101/2023.09.15.557808
   work_id: work_0e82b896b4b49d23
@@ -17964,110 +18100,6 @@ papers:
       title: A mesoscale connectome of the mouse brain
       year: 2014
     cited_by: []
-- id: strner-2024-2024-06-04-596633
-  uuid: 10.1101/2024.06.04.596633
-  work_id: work_68c16753f9b50e6c
-  title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-  authors: T. Stürner; Paul Brooks; L. Capdevila; Billy J. Morris; A. Javier; Siqi Fang; Marina Gkantia; S. Cachero; Isabella R. Beckett; A. Champion; Ilina Moitra; Alana Richards; Finja Klemm; Leonie Kugel; S. Namiki; H. S. Cheong; Julie Kovalyak; Emily Tenshaw; Ruchi Parekh; P. Schlegel; Jasper S. Phelps; Brandon Mark; S. Dorkenwald; A. S. Bates; Arie Matsliah; Szi-chieh Yu; Claire E. McKellar; A. Sterling; Sebastian Seung; M. Murthy; John C. Tuthill; W. Lee; G. Card; Marta Costa; G. Jefferis; K. Eichler
-  year: 2024
-  journal: bioRxiv
-  doi: 10.1101/2024.06.04.596633
-  dimension: proofreading
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 13
-  in_degree: 8
-  out_degree: 17
-  annotation_status: generated_from_pdf
-  tags:
-  - fly
-  - descending neurons
-  - ascending neurons
-  - vnc
-  - sexual dimorphism
-  - electron microscopy
-  - neck connective
-  ocar:
-    opportunity: In insects the neck connective is a physical and informational bottleneck between brain and ventral nerve cord, so a complete account of descending, ascending, and sensory ascending neurons is needed to link sensation to action.
-    challenge: These neurons are split across brain and nerve-cord EM volumes and differ by sex, so they must be matched across hemispheres, datasets, and sexes and tied to genetic driver lines.
-    action: Stürner, Brooks, Jefferis, Eichler and colleagues, on bioRxiv (2024), integrate three EM datasets to proofread and match female Drosophila descending and ascending neurons, compare them with the male nerve cord, match 51% of descending cell types to light-level driver lines, and classify all ascending populations.
-    resolution: They describe architecture, tracts, neuropil innervation, and connectivity of neck-connective neurons, including chains of descending and ascending neurons spanning the neck that may subserve motor sequences, and a complete account of sexually dimorphic DN and AN populations implicated in female ovipositor extrusion (DNp13), male courtship (DNa12/aSP22), and song (AN hemilineage 08B). They frame this as the first EM-level circuit analyses spanning an adult animal’s entire central nervous system.
-    future_work: Completing driver-line matches beyond the reported 51% of DN types, and functional tests of the identified dimorphic circuits, would close the loop from EM identity to behavior.
-  plain_language_summary: Messages between a fly’s brain and its body travel through a narrow neck. This team finished mapping those up and down neurons in a female fly, compared them with a male, and tied many types to genetic tools.
-  summaries:
-    beginner: Messages between a fly’s brain and its body travel through a narrow neck. This team finished mapping those up and down neurons in a female fly, compared them with a male, and tied many types to genetic tools.
-    intermediate: Posted on bioRxiv (2024), Stürner and colleagues present a complete connectomic description of Drosophila ascending and descending neurons in the female nervous system, integrating three EM datasets and comparing them with the male nerve cord. Proofread reconstructions were matched across hemispheres, datasets, and sexes; 51% of descending cell types were matched to light-level driver lines, and all ascending populations were classified. The authors report neck-spanning DN–AN chains and sexually dimorphic populations, including circuits for ovipositor extrusion, male courtship, and song.
-    advanced: The selected PDF extract captured the abstract and introduction plus the reference list rather than a dedicated discussion, so circuit interpretations follow the abstract. “Complete” refers to matched ascending/descending populations, not every neuron in brain plus VNC. Driver-line matching is 51% of DN types. Behavioral roles are assigned via implicated circuits and prior literature, not new behavior experiments in this extract. Sexual dimorphism analyses depend on cross-dataset matching between female and male nerve cords.
-  discussion_prompts:
-  - What problem in proofreading does this paper actually solve, and what would falsify that?
-  - How far does this transfer beyond DS07 VNC (FANC/MANC)?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2024.06.04.596633.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2024.06.04.596633
-  era: '2024'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 81
-  streams:
-    axis: pipeline_stage
-    stages:
-    - proofreading
-    datasets:
-    - DS07 VNC (FANC/MANC)
-    organism:
-    - fly
-    method:
-    - electron microscopy
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: winding-2022-science-add9330
-      title: The connectome of an insect brain
-      year: 2022
-    - id: takemura-2023-2023-06-05-543757
-      title: A Connectome of the Male Drosophila Ventral Nerve Cord
-      year: 2023
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
-    - id: zheng-2017-j-cell-2018-06-019
-      title: A Complete Electron Microscopy Volume of the Brain of Adult Drosophila melanogaster
-      year: 2017
-    - id: eckstein-2020-j-cell-2024-03-016
-      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
-      year: 2020
-    - id: cook-2019-s41586-019-1352-7
-      title: Whole-animal connectomes of both Caenorhabditis elegans sexes
-      year: 2019
-    - id: schlegel-2020-elife-66018
-      title: Information flow, cell types and stereotypy in a full olfactory connectome
-      year: 2020
-    - id: bates-2020-elife-53350
-      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
-      year: 2020
-    cited_by:
-    - id: schlegel-2024-s41586-024-07686-5
-      title: Whole-brain annotation and multi-connectome cell typing of Drosophila
-      year: 2024
-    - id: dorkenwald-2024-s41586-024-07558-y
-      title: Neuronal wiring diagram of an adult brain
-      year: 2024
-    - id: lesser-2024-s41586-024-07600-z
-      title: Synaptic architecture of leg and wing premotor control networks in Drosophila
-      year: 2024
-    - id: zdil-2026-s41467-026-72152-x
-      title: Centralized brain networks controlling antennal grooming coordination
-      year: 2026
-    - id: schretter-2024-s41586-024-08255-6
-      title: Social state alters vision using three circuit mechanisms in Drosophila
-      year: 2024
 - id: tao-2024-jneurosci-0142-24-20
   uuid: 10.1523/jneurosci.0142-24.2024
   work_id: work_beb149e7e1eaddc1
@@ -18880,8 +18912,8 @@ papers:
     - id: takemura-2013-nature12450
       title: A visual motion detection circuit suggested by Drosophila connectomics
       year: 2013
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -19353,72 +19385,6 @@ papers:
       title: Connectomic analysis of the Drosophila lateral neuron clock cells reveals the synaptic basis of functional pacemaker classes
       year: 2022
     cited_by: []
-- id: zdil-2024-2024-12-17-628844
-  uuid: 10.1101/2024.12.17.628844
-  work_id: work_7599ba180a4cf46f
-  title: Centralized brain networks underlie body part coordination during grooming
-  authors: P. G. Özdil; Jonathan Arreguit; Clara Scherrer; A. Ijspeert; Pavan Ramdya
-  year: 2024
-  journal: bioRxiv
-  doi: 10.1101/2024.12.17.628844
-  dimension: graph-analysis
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 1
-  in_degree: 1
-  out_degree: 0
-  annotation_status: generated_from_pdf
-  tags:
-  - drosophila
-  - grooming
-  - motor control
-  - connectome
-  - preprint
-  - coordination
-  ocar:
-    opportunity: Coordinated multi-body-part actions such as grooming are a tractable place to ask how a nervous system synchronizes effectors, using a complete fly brain connectome.
-    challenge: It was unknown whether coordination requires proprioceptive coupling among head, antennae, and forelegs, or whether a central controller can co-recruit motor networks.
-    action: Özdil, Arreguit, Scherrer, Ijspeert, and Ramdya, on bioRxiv (2024), combine Drosophila antennal-grooming kinematics, a biomechanical simulation, lesion/immobilization experiments, and a grooming network built from the fly brain connectome, plus a simulated activation screen.
-    resolution: Unilateral or bilateral antennal grooming arises from synchronized head, antenna, and foreleg movements that a biomechanical replay shows make tibia–antenna collisions more efficient. Amputation or head immobilization does not stop the other parts, implying coordination is not required proprioceptive feedback. Central interneurons and shared premotor neurons link neck, antennal, and foreleg motor networks. Two motifs—recurrent excitation promoting contralateral antennal pitch and broadcast inhibition suppressing ipsilateral pitch—account for unilateral coordination in the screen.
-    future_work: The authors suggest similarly centralized controllers may co-recruit body parts for other behaviors; those generalizations are not demonstrated here.
-  plain_language_summary: When a fly grooms its antennae, the head, antennae, and front legs move together on purpose. Mapping the responsible neurons in the fly connectome points to a central controller, not a chain of reflexes that wait on each body part to feel the others.
-  summaries:
-    beginner: When a fly grooms its antennae, the head, antennae, and front legs move together on purpose. Mapping the responsible neurons in the fly connectome points to a central controller, not a chain of reflexes that wait on each body part to feel the others.
-    intermediate: Özdil et al. (bioRxiv, 17 December 2024) study goal-directed antennal grooming in Drosophila. Kinematics plus a biomechanical model indicate that coordination yields unobstructed, forceful tibia–antenna collisions. Foreleg or antenna amputation, or head immobilization, leaves other parts moving, so proprioceptive coupling is not required. A connectome-derived antennal-grooming network implicates centralized interneurons and shared premotor neurons. A simulated activation screen highlights a recurrent excitatory motif for contralateral antennal pitch and broadcast inhibition of ipsilateral pitch.
-    advanced: This is a preprint. The extract’s later pages are references; quantitative screen results live in figures not fully captured. ‘Comprehensive’ network means a reconstructed subgraph from the fly brain connectome, not a new EM volume. Catalog method tags are empty; the work is connectome analysis plus behavior and modeling.
-  discussion_prompts:
-  - What problem in graph_analysis, modeling does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2024.12.17.628844.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2024.12.17.628844
-  era: '2024'
-  why: contemporary_keep
-  citation_role: no_graph
-  link_strength: ''
-  year_cites_percentile: 60
-  streams:
-    axis: pipeline_stage
-    stages:
-    - graph_analysis
-    - modeling
-    datasets: []
-    organism:
-    - fly
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites: []
-    cited_by:
-    - id: calleschuler-2026-elife-108044
-      title: A comprehensive mechanosensory connectome reveals a somatotopically organized neural circuit architecture controlling stimulus-aimed grooming of the Drosophila head
-      year: 2026
 - id: zhang-2024-elife-87866
   uuid: 10.7554/elife.87866
   work_id: work_14a97091f2e2dc94
@@ -19484,9 +19450,9 @@ papers:
     - id: shapsoncoe-2021-2021-05-29-446289
       title: A connectomic study of a petascale fragment of human cerebral cortex
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: bae-2021-s41586-025-08790-w
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
@@ -19762,81 +19728,6 @@ papers:
     - id: kim-2026-2026-02-02-700492
       title: Connectome analysis reveals brainwide visual processing in Drosophila
       year: 2026
-- id: anneser-2023-2023-10-04-560846
-  uuid: 10.1101/2023.10.04.560846
-  work_id: work_5dc288699a486219
-  title: Molecular logic of neuromodulatory systems in the zebrafish telencephalon
-  authors: Lukas Anneser; Chie Satou; H. Hotz; R. Friedrich
-  year: 2023
-  journal: bioRxiv
-  doi: 10.1101/2023.10.04.560846
-  dimension: connectomics
-  reading_phase: 2_contemporary
-  role: survey
-  inclusion_role: contemporary
-  k_core: 4
-  in_degree: 0
-  out_degree: 4
-  annotation_status: generated_from_pdf
-  tags:
-  - zebrafish
-  - neuromodulation
-  - gpcr
-  - cell types
-  - telencephalon
-  - transcriptomics
-  - neuropeptides
-  ocar:
-    opportunity: Circuit function depends on neuromodulation as well as synapses; a molecular map of GPCRs and cell types in adult zebrafish telencephalon would constrain that extra layer.
-    challenge: How combinatorial monoamine and neuropeptide systems weight each transcriptionally defined cell type, and how those types relate phylogenetically to other vertebrates, was unclear at high granularity.
-    action: On bioRxiv (5 October 2023), Anneser, Satou, Hotz, and Friedrich combine bulk and deep single-cell transcriptomics with HCR spatial mapping of markers and GPCRs in adult zebrafish telencephalon.
-    resolution: They report 55 neuronal types mapped to telencephalic areas; every type is modulated by multiple monoamines and peptide combinations, typically >30 networks, but only a few diagnostic GPCRs at high level. SAMap alignments support conserved cell types with reptiles (bearded dragon) and other vertebrates, including Dl–hippocampus and Dc–isocortex links.
-    future_work: Dc cell types were not clearly split, possibly due to heterogeneity and low abundance; whether Dl’s posterior/medial–anterior/lateral molecular axis is functional remains unknown.
-  plain_language_summary: Brain cells are not only wired by synapses; they are also bathed in chemical messengers. This zebrafish atlas shows each cell type listens to many messengers but really “turns up” only a few, and some types look related to those in other vertebrates.
-  summaries:
-    beginner: Brain cells are not only wired by synapses; they are also bathed in chemical messengers. This zebrafish atlas shows each cell type listens to many messengers but really “turns up” only a few, and some types look related to those in other vertebrates.
-    intermediate: In a bioRxiv preprint (2023; 10.1101/2023.10.04.560846), Anneser and colleagues profile adult zebrafish telencephalon. Bulk sequencing distinguishes pallial subregions; scRNA-seq yields 55 neuronal types placed with HCR. Combinatorial GPCR logic implies all types receive multi-system modulation with unequal weights. Spatial maps refine Dp, Dl, Dm compartments (e.g., pDp vs. aDp). Phylogenetic SAMap links a subset of types to bearded dragon and, by extension, other vertebrates.
-    advanced: “Typically >30” networks per type is from the abstract; it is association of expression programs, not measured co-release. Volume EM is cited as the synaptic-diagram complement, not performed here. Catalog dataset DS15 zebrafish is transcriptomic/spatial, not a synapse map. Unedited preprint (October 2023).
-  discussion_prompts:
-  - What problem in the connectomics pipeline does this paper actually solve, and what would falsify that?
-  - How far does this transfer beyond DS15 zebrafish?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2023.10.04.560846.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2023.10.04.560846
-  era: '2023'
-  why: contemporary_keep
-  citation_role: only_out
-  link_strength: moderate
-  year_cites_percentile: 6
-  streams:
-    axis: registry_dataset
-    stages: []
-    datasets:
-    - DS15 zebrafish
-    organism:
-    - zebrafish
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: wanner-2020-s41593-019-0576-z
-      title: Whitening of odor representations by the wiring diagram of the olfactory bulb
-      year: 2020
-    - id: ripollsnchez-2022-j-neuron-2023-09-043
-      title: The neuropeptidergic connectome of C. elegans
-      year: 2022
-    - id: williams-2017-elife-26349
-      title: Synaptic and peptidergic connectome of a neurosecretory center in the annelid brain
-      year: 2017
-    - id: bentley-2016-journal-pcbi-1005283
-      title: The Multilayer Connectome of Caenorhabditis elegans
-      year: 2016
-    cited_by: []
 - id: anneser-2023-j-cub-2023-12-003
   uuid: 10.1016/j.cub.2023.12.003
   work_id: work_9a4cc4ec5c4fadb0
@@ -19849,9 +19740,9 @@ papers:
   reading_phase: 2_contemporary
   role: survey
   inclusion_role: contemporary
-  k_core: 3
+  k_core: 4
   in_degree: 0
-  out_degree: 3
+  out_degree: 4
   annotation_status: generated_from_pdf
   tags:
   - zebrafish
@@ -19907,7 +19798,12 @@ papers:
     - id: bentley-2016-journal-pcbi-1005283
       title: The Multilayer Connectome of Caenorhabditis elegans
       year: 2016
+    - id: ripollsnchez-2022-j-neuron-2023-09-043
+      title: The neuropeptidergic connectome of C. elegans
+      year: 2022
     cited_by: []
+  alt_dois:
+  - 10.1101/2023.10.04.560846
 - id: aso-2023-elife-85756
   uuid: 10.7554/elife.85756
   work_id: work_f29d7babf92878d9
@@ -19970,15 +19866,12 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
       year: 2024
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: takemura-2017-elife-26975
       title: A connectome of a learning and memory center in the adult Drosophila brain
       year: 2017
@@ -21392,9 +21285,9 @@ papers:
       title: A Connectome of the Male Drosophila Ventral Nerve Cord
       year: 2023
     cited_by:
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: lesser-2026-elife-107867
       title: Peripheral anatomy and central connectivity of proprioceptive sensory neurons in the Drosophila wing
       year: 2026
@@ -21836,9 +21729,9 @@ papers:
     - id: holler-2019-s41586-020-03134-2
       title: Structure and function of a neocortical synapse
       year: 2019
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: turner-2019-isbi45749-2020-90984
       title: Synaptic Partner Assignment Using Attentional Voxel Association Networks
       year: 2019
@@ -21846,9 +21739,9 @@ papers:
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
     cited_by:
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -22346,96 +22239,6 @@ papers:
       year: 2022
     - id: swanson-2016-annurev-neuro-071714
       title: From Cajal to Connectome and Beyond.
-      year: 2016
-    cited_by: []
-- id: han-2023-v1
-  uuid: 10.21203/rs.3.rs-3121892/v1
-  work_id: work_1abefbc844f53786
-  title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-  authors: Xiaomeng Han; Xiaotang Lu; Peter H. Li; Shuohong Wang; R. Schalek; Y. Meirovitch; Zudi Lin; Jason Adhinarta; D. Berger; Yuelong Wu; Tao Fang; Elif Sevde Meral; Shadnan Asraf; H. Ploegh; H. Pfister; D. Wei; Viren Jain; J. Trimmer; J. Lichtman
-  year: 2023
-  journal: Research Square
-  doi: 10.21203/rs.3.rs-3121892/v1
-  dimension: image-acquisition
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 13
-  in_degree: 0
-  out_degree: 21
-  annotation_status: generated_from_pdf
-  tags:
-  - mouse
-  - cerebellum
-  - clem
-  - scfv
-  - serial-section em
-  - immunolabeling
-  - mossy fibers
-  ocar:
-    opportunity: Serial-section EM can reconstruct synaptic networks but lacks the molecular labels that identify cell types and functional properties. Volumetric correlated light and electron microscopy (vCLEM) can overlay fluorescence on the same EM volume if probes penetrate without detergents that ruin ultrastructure.
-    challenge: Conventional antibodies are large and usually need detergents, which conflict with EM preservation. Multiplexed molecular contrast on a single connectomic sample therefore requires smaller probes that still bind useful markers.
-    action: Han, Lu, Li, Wang, Schalek, Meirovitch, Lichtman, Trimmer and colleagues (Research Square, 2023) generated eight fluorescent single-chain variable fragment (scFv) immuno-probes against GFP, GFAP, calbindin, parvalbumin, Kv1.2 (KCNA2), VGLUT1, PSD-95, and neuropeptide Y. They performed detergent-free multiplexed labeling, confocal imaging with spectral unmixing, then ssEM on the same mouse cerebellar Crus I sample, depositing plasmids at Addgene.
-    resolution: Six probes were imaged together with excellent ultrastructure and superimposed fluorescence channels. The volume documented a poorly described cerebellar cell type, two types of mossy-fiber terminals, and subcellular localization of one ion-channel type. Usable vCLEM volumes reached 120 μm depth; scFv conversion from NeuroMab monoclonal antibodies is reported at about 50%. A version of record later appeared in Nature Communications (2024).
-    future_work: The authors argue that because scFvs can be derived from existing monoclonal antibodies, hundreds of probes could be generated; they discuss conversion strategies, combinatorial cell typing, and combining scFv labeling with calcium or voltage imaging.
-  plain_language_summary: Electron-microscope maps show every wire but not which molecular “name tags” a cell carries. This team makes tiny fluorescent antibody pieces that soak into tissue without soap, so the same mouse cerebellum chunk can be seen in color and then in EM detail.
-  summaries:
-    beginner: Electron-microscope maps show every wire but not which molecular “name tags” a cell carries. This team makes tiny fluorescent antibody pieces that soak into tissue without soap, so the same mouse cerebellum chunk can be seen in color and then in EM detail.
-    intermediate: Posted on Research Square (2023), Han, Lichtman, Trimmer and colleagues introduce detergent-free scFv immuno-probes for multiplexed volumetric CLEM. Eight fluorescent scFvs target GFP, GFAP, calbindin, parvalbumin, Kv1.2, VGLUT1, PSD-95, and NPY; six were unmixed by confocal microscopy on mouse cerebellar Crus I and followed by serial-section EM. They report excellent ultrastructure with registered fluorescence, a poorly described cerebellar cell type, two mossy-fiber terminal types, ion-channel subcellular localization, and ~120 μm usable depth. Expression plasmids are deposited at Addgene.
-    advanced: This is a methods-and-cytology preprint (later Nature Communications 2024); “hundreds of probes” is a projection from monoclonal libraries, not a count delivered here. Conversion success is ~50% for the NeuroMab recombinant subset attempted. Six-color unmixing is not an upper bound—the discussion cites published 45-color linear unmixing and Raman dyes as possible extensions, not results of this experiment. Depth is limited by confocal imaging of uncleared tissue even though scFvs penetrate further.
-  discussion_prompts:
-  - What problem in sectioning does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.researchsquare.com/article/rs-3121892/latest.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.21203/rs.3.rs-3121892/v1
-  era: '2023'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 35
-  streams:
-    axis: pipeline_stage
-    stages:
-    - sectioning
-    datasets: []
-    organism:
-    - mouse
-    method:
-    - serial-section EM
-    - CLEM
-    - confocal
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: dorkenwald-2022-s41592-023-02059-8
-      title: Multi-layered maps of neuropil with segmentation-guided contrastive learning
-      year: 2022
-    - id: briggman-2011-nature09818
-      title: Wiring specificity in the direction-selectivity circuit of the retina
-      year: 2011
-    - id: shapsoncoe-2021-2021-05-29-446289
-      title: A connectomic study of a petascale fragment of human cerebral cortex
-      year: 2021
-    - id: pavarino-2023-fncir-2023-952921
-      title: 'mEMbrain: an interactive deep learning MATLAB tool for connectomic segmentation on commodity desktops'
-      year: 2023
-    - id: karlupia-2023-j-biopsych-2023-01-0
-      title: Immersion fixation and staining of multi-cubic millimeter volumes for electron microscopy-based connectomics of human brain biopsies
-      year: 2023
-    - id: bock-2011-nature09802
-      title: Network anatomy and in vivo physiology of visual cortical neurons
-      year: 2011
-    - id: januszewski-2017-s41592-018-0049-4
-      title: High-precision automated reconstruction of neurons with flood-filling networks
-      year: 2017
-    - id: lee-2016-nature17192
-      title: Anatomy and function of an excitatory network in the visual cortex
       year: 2016
     cited_by: []
 - id: hellevik-2023-2023-09-12-557433
@@ -23235,9 +23038,9 @@ papers:
       title: Connectomic comparison of mouse and human cortex
       year: 2022
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -23253,9 +23056,6 @@ papers:
     - id: chen-2023-cvprw59228-2023-0045
       title: Learning to Correct Sloppy Annotations in Electron Microscopy Volumes
       year: 2023
-    - id: han-2024-s41467-024-50411-z
-      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
-      year: 2024
     - id: lu-2023-2023-09-26-558265
       title: A Scalable Staining Strategy for Whole-Brain Connectomics
       year: 2023
@@ -23423,112 +23223,6 @@ papers:
       title: Conserved neural circuit structure across Drosophila larval development revealed by comparative connectomics
       year: 2017
     cited_by: []
-- id: lappalainen-2023-2023-03-11-532232
-  uuid: 10.1101/2023.03.11.532232
-  work_id: work_fafef48ad68a0f38
-  title: Connectome-constrained deep mechanistic networks predict neural responses across the fly visual system at single-neuron resolution
-  authors: Janne K. Lappalainen; Fabian Tschopp; Sridhama Prakhya; Mason McGill; Aljoscha Nern; Kazunori Shinomiya; Shin-ya Takemura; Eyal Gruntman; J. Macke; Srinivas C. Turaga
-  year: 2023
-  journal: bioRxiv
-  doi: 10.1101/2023.03.11.532232
-  dimension: neuroai
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 13
-  in_degree: 6
-  out_degree: 12
-  annotation_status: generated_from_pdf
-  tags:
-  - fly
-  - optic lobe
-  - motion detection
-  - deep mechanistic network
-  - connectome-constrained
-  - visual system
-  - sparsity
-  ocar:
-    opportunity: We can now measure the connectivity of every neuron in a circuit, but not the dynamical properties of every neuron and synapse. Whether connectivity measurements alone can predict the activity underlying a computation is an open question, and there has been considerable debate about the utility of connectomes for understanding brain function.
-    challenge: Electrical synapses, neuromodulation, and glia also shape activity, and there is evidence from computer science and neuroscience that connectivity does not usually uniquely determine function. Unknown single-neuron and single-synapse parameters must be filled in somehow.
-    action: Lappalainen, Tschopp, Macke, Turaga and colleagues, on bioRxiv (2023), construct a deep mechanistic network with the experimentally determined connectivity of 64 cell types in the motion pathways of the fruit fly optic lobe, then optimize unknown neuron and synapse parameters with deep-learning methods so the network detects visual motion.
-    resolution: The model makes experimentally testable predictions for each neuron in the connectome and agreed with experimental measurements of neural activity across 24 studies. The authors argue the strategy is more likely to succeed when neurons are sparsely connected—a universally observed feature of biological networks—and they include simulated-network analyses linking sparsity to larger, more recoverable local minima.
-    future_work: The work is offered as a strategy for generating detailed mechanistic hypotheses from connectivity. Testing the same constrained-optimization approach on less sparse circuits, and adding biological details still missing from the model, would bound when connectome-only prediction succeeds.
-  plain_language_summary: We can map every connection in a circuit and still not know how each cell fires. This team freezes the fly visual system’s wiring, tunes the unknown cell and synapse knobs so the network detects motion, and finds that the predicted activity matches many published experiments.
-  summaries:
-    beginner: We can map every connection in a circuit and still not know how each cell fires. This team freezes the fly visual system’s wiring, tunes the unknown cell and synapse knobs so the network detects motion, and finds that the predicted activity matches many published experiments.
-    intermediate: Posted on bioRxiv (2023), Lappalainen and colleagues build a model of 64 cell types in the Drosophila optic-lobe motion pathways using experimentally determined connectivity but unknown single-neuron and synapse parameters. Those parameters are optimized with deep-learning methods so the network detects visual motion. Model predictions agreed with neural activity measurements across 24 studies. The authors conclude that connectome-constrained modeling can yield detailed, testable hypotheses, especially in sparsely connected biological networks.
-    advanced: The selected PDF extract captured methods supplements on Dale’s-law sign constraints and weight-noise simulations rather than a prose Discussion. Agreement with 24 studies is a literature comparison, not a new simultaneous recording of the full model. Parameters are fitted to a motion-detection objective, so success tests whether that task plus anatomy recover observed tunings. Simulated digit-classification networks in the supplement support the sparsity claim but are not fly visual neurons. Electrical synapses, neuromodulation, and glia are acknowledged as unmodeled factors in the introduction.
-  discussion_prompts:
-  - What problem in modeling does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2023.03.11.532232.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2023.03.11.532232
-  era: '2023'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 87
-  streams:
-    axis: pipeline_stage
-    stages:
-    - modeling
-    datasets: []
-    organism:
-    - fly
-    method:
-    - Connectome-constrained visual-system model
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: takemura-2013-nature12450
-      title: A visual motion detection circuit suggested by Drosophila connectomics
-      year: 2013
-    - id: dorkenwald-2020-s41592-021-01330-0
-      title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: shapsoncoe-2021-2021-05-29-446289
-      title: A connectomic study of a petascale fragment of human cerebral cortex
-      year: 2021
-    - id: hulse-2020-2020-12-08-413955
-      title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
-      year: 2020
-    - id: svara-2022-s41592-022-01621-0
-      title: Automated synapse-level reconstruction of neural circuits in the larval zebrafish brain
-      year: 2022
-    - id: liu-2021-2021-08-19-456845
-      title: Connectomic features underlying diverse synaptic connection strengths and subcellular computation
-      year: 2021
-    - id: oh-2014-nature13186
-      title: A mesoscale connectome of the mouse brain
-      year: 2014
-    - id: motta-2018-science-aay3134
-      title: Dense connectomic reconstruction in layer 4 of the somatosensory cortex
-      year: 2018
-    cited_by:
-    - id: pospisil-2024-s41586-024-07982-0
-      title: The fly connectome reveals a path to the effectome
-      year: 2024
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
-    - id: eckstein-2020-j-cell-2024-03-016
-      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
-      year: 2020
-    - id: bae-2021-s41586-025-08790-w
-      title: Functional connectomics spanning multiple areas of mouse visual cortex
-      year: 2021
-    - id: joyce-2023-2023-10-20-563359
-      title: A Novel Semi-automated Proofreading and Mesh Error Detection Pipeline for Neuron Extension
-      year: 2023
-    - id: beiran-2024-s41593-025-02080-4
-      title: Prediction of neural activity in connectome-constrained recurrent networks
-      year: 2024
 - id: lauenburg-2023-jbhi-2023-3281332
   uuid: 10.1109/jbhi.2023.3281332
   work_id: work_6e58cd7663b2ca89
@@ -23930,9 +23624,6 @@ papers:
       title: 'NeuronBridge: an intuitive web application for neuronal morphology search across large data sets'
       year: 2022
     cited_by:
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
     - id: strner-2025-s41586-025-08925-z
       title: Comparative connectomics of Drosophila descending and ascending neurons
       year: 2025
@@ -24174,9 +23865,9 @@ papers:
     - id: gerhard-2017-143727
       title: Conserved neural circuit structure across Drosophila larval development revealed by comparative connectomics
       year: 2017
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: schubert-2022-s41592-022-01624-x
       title: 'SyConn2: dense synaptic connectivity inference for volume electron microscopy'
       year: 2022
@@ -25126,9 +24817,9 @@ papers:
     - id: holler-2019-s41586-020-03134-2
       title: Structure and function of a neocortical synapse
       year: 2019
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: bae-2021-s41586-025-08790-w
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
@@ -25227,15 +24918,12 @@ papers:
       title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
-    - id: bidel-2022-elife-84257
-      title: Connectomics of the Octopus vulgaris vertical lobe provides insight into conserved and novel principles of a memory acquisition network
-      year: 2022
     - id: han-2024-s41467-024-50411-z
       title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
       year: 2024
+    - id: bidel-2022-elife-84257
+      title: Connectomics of the Octopus vulgaris vertical lobe provides insight into conserved and novel principles of a memory acquisition network
+      year: 2022
     - id: lu-2023-2023-09-26-558265
       title: A Scalable Staining Strategy for Whole-Brain Connectomics
       year: 2023
@@ -25893,120 +25581,6 @@ papers:
     - id: cornean-2023-s41467-024-45971-z
       title: Heterogeneity of synaptic connectivity in the fly visual system
       year: 2023
-- id: schneidermizell-2023-2023-01-23-525290
-  uuid: 10.1101/2023.01.23.525290
-  work_id: work_55a31c8884d2dba2
-  title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-  authors: C. Schneider-Mizell; A. Bodor; D. Brittain; J. Buchanan; D. Bumbarger; L. Elabbady; D. Kapner; S. Kinn; G. Mahalingam; S. Seshamani; S. Suckow; Marc M. Takeno; R. Torres; W. Yin; S. Dorkenwald; J. Bae; M. Castro; Paul G. Fahey; Emmanouil Froudakis; A. Halageri; Z. Jia; C. Jordan; N. Kemnitz; Kisuk Lee; Kai Li; R. Lu; T. Macrina; E. Mitchell; S. Mondal; S. Mu; Barak Nehoran; S. Papadopoulos; Saumil S. Patel; X. Pitkow; S. Popovych; W. Silversmith; Fabian H. Sinz; N. Turner; W. Wong; Jingpeng Wu; Szi-chieh Yu; J. Reimer; A. Tolias; H. Seung; R. Reid; F. Collman; N. D. da Costa
-  year: 2023
-  journal: bioRxiv
-  doi: 10.1101/2023.01.23.525290
-  dimension: segmentation
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 13
-  in_degree: 11
-  out_degree: 28
-  annotation_status: generated_from_pdf
-  tags:
-  - mouse
-  - visual cortex
-  - inhibition
-  - electron microscopy
-  - cell types
-  - motifs
-  - layer 5
-  - microns
-  ocar:
-    opportunity: Mammalian cortex features a vast diversity of neuronal cell types, but it has been unclear how morphological and projection-class differences among excitatory neurons are reflected in local inhibitory circuitry.
-    challenge: Mapping connectivity rules at distinct-cell-type resolution remains difficult without dense millimeter-scale EM, classification of inhibitory targeting, and a data-driven excitatory taxonomy from morphology and synaptic input.
-    action: Schneider-Mizell, Bodor, da Costa and colleagues, on bioRxiv (2023), use volumetric EM to census all inhibitory neurons among 1,352 densely segmented cells spanning all layers of mouse visual cortex, reconstructing more than 70,000 synapses.
-    resolution: Connectivity revealed a disinhibitory specialist targeting basket cells, widespread interneuron specificity for intermingled excitatory subpopulations, and motif groups that collectively innervate perisomatic and dendritic compartments of the same excitatory targets. Excitatory M-types defined from morphology plus synaptic input showed distinct inhibitory-input patterns, including several non-overlapping inhibitory networks within layer 5 (ET versus IT, L5ITa versus L5ITb, and NP cells) and distinct as well as shared inhibition of layer 6 IT versus corticothalamic cells.
-    future_work: The census is offered as a foundation for linking multimodal atlases to cortical wiring. The discussion’s layer-5 and layer-6 examples imply that similar subtype-resolved maps in other areas, and alignment with transcriptomic types, are the natural next uses of the resource.
-  plain_language_summary: This preprint maps how inhibitory cells connect inside a column of mouse visual cortex. It finds that inhibition is organized into repeating targeting patterns, not a uniform blanket, and that even neurons in the same layer can sit in different inhibitory networks.
-  summaries:
-    beginner: This preprint maps how inhibitory cells connect inside a column of mouse visual cortex. It finds that inhibition is organized into repeating targeting patterns, not a uniform blanket, and that even neurons in the same layer can sit in different inhibitory networks.
-    intermediate: 'Posted on bioRxiv (2023), Schneider-Mizell and colleagues reconstruct inhibitory connectivity among 1,352 densely segmented neurons spanning all layers of mouse visual cortex, with more than 70,000 synapses. Inhibitory neurons are classified by relative targeting of dendritic compartments and other inhibitory cells; excitatory neurons are classified from morphology and synaptic-input properties. Results include a basket-cell-targeting disinhibitory specialist, motif groups jointly covering soma and dendrites, and sublaminar specificity: extra-telencephalic layer-5 cells received more numerous and diverse inhibitory inputs than intra-telencephalic cells, with further splits inside L5IT and distinct layer-6 projection-class networks.'
-    advanced: This is the preprint counterpart of the 2025 Nature inhibitory-census paper, with the same 1,352-cell and >70,000-synapse figures; findings should not be double-counted as independent replications. Classification is structural, not molecular. ET/IT and CT distinctions depend on morphological assignment in the EM volume. Specificity among spatially intermingled targets is a key claim without a single selectivity statistic in the extract.
-  discussion_prompts:
-  - What problem in segmentation, graph_analysis does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2023.01.23.525290.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2023.01.23.525290
-  era: '2023'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 91
-  streams:
-    axis: pipeline_stage
-    stages:
-    - segmentation
-    - graph_analysis
-    datasets: []
-    organism:
-    - mouse
-    method:
-    - electron microscopy
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: schneidermizell-2021-elife-73783
-      title: Structure and function of axo-axonic inhibition
-      year: 2021
-    - id: dorkenwald-2020-s41592-021-01330-0
-      title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: dorkenwald-2022-s41592-023-02059-8
-      title: Multi-layered maps of neuropil with segmentation-guided contrastive learning
-      year: 2022
-    - id: white-1986-rstb-1986-0056
-      title: The structure of the nervous system of the nematode Caenorhabditis elegans
-      year: 1986
-    - id: shapsoncoe-2021-2021-05-29-446289
-      title: A connectomic study of a petascale fragment of human cerebral cortex
-      year: 2021
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
-    - id: hua-2015-ncomms8923
-      title: Large-volume en-bloc staining for electron microscopy-based connectomics
-      year: 2015
-    - id: lee-2016-nature17192
-      title: Anatomy and function of an excitatory network in the visual cortex
-      year: 2016
-    cited_by:
-    - id: salova-2024-netn-a-00428
-      title: Combined topological and spatial constraints are required to capture the structure of neural connectomes
-      year: 2024
-    - id: troidl-2023-2022-12-09-519772
-      title: ViMO - Visual Analysis of Neuronal Connectivity Motifs
-      year: 2023
-    - id: ding-2025-s41586-025-08840-3
-      title: Functional connectomics reveals general wiring rule in mouse visual cortex
-      year: 2025
-    - id: lesser-2024-s41586-024-07600-z
-      title: Synaptic architecture of leg and wing premotor control networks in Drosophila
-      year: 2024
-    - id: gamlin-2023-2023-03-22-533857
-      title: 'Integrating EM and Patch-seq data: Synaptic connectivity and target specificity of predicted Sst transcriptomic types'
-      year: 2023
-    - id: pokorny-2024-2024-05-24-593860
-      title: A connectome manipulation framework for the systematic and reproducible study of structure–function relationships through simulations
-      year: 2024
-    - id: reimann-2024-bhae433
-      title: Specific inhibition and disinhibition in the higher-order structure of a cortical connectome
-      year: 2024
-    - id: patio-2023-elife-89297
-      title: Postsynaptic cell type and synaptic distance do not determine efficiency of monosynaptic rabies virus spread measured at synaptic resolution
-      year: 2023
 - id: seung-2023-2023-11-15-567126
   uuid: 10.1101/2023.11.15.567126
   work_id: work_1ded1883d45ddd82
@@ -26079,95 +25653,6 @@ papers:
       title: Identifying Inputs to Visual Projection Neurons in Drosophila Lobula by Analyzing Connectomic Data
       year: 2022
     cited_by: []
-- id: shiu-2023-2023-05-02-539144
-  uuid: 10.1101/2023.05.02.539144
-  work_id: work_16b9df3949da837d
-  title: A leaky integrate-and-fire computational model based on the connectome of the entire adult Drosophila brain reveals insights into sensorimotor processing
-  authors: Philip K. Shiu; Gabriella R. Sterne; N. Spiller; R. Franconville; Andrea Sandoval; Joie Zhou; Neha Simha; C. Kang; Seongbong Yu; Jinseop S. Kim; S. Dorkenwald; Arie Matsliah; P. Schlegel; Szi-chieh Yu; Claire E. McKellar; A. Sterling; Marta Costa; K. Eichler; G. Jefferis; M. Murthy; A. S. Bates; N. Eckstein; Jan Funke; Salil S. Bidaye; Stefanie Hampel; A. Seeds; Kristin Scott
-  year: 2023
-  journal: bioRxiv
-  doi: 10.1101/2023.05.02.539144
-  dimension: neuroai
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 8
-  in_degree: 3
-  out_degree: 6
-  annotation_status: generated_from_pdf
-  tags:
-  - drosophila
-  - flywire
-  - leaky integrate-and-fire
-  - gustatory
-  - sensorimotor
-  - whole-brain model
-  ocar:
-    opportunity: The adult Drosophila central brain connectome—over 125,000 neurons and 50 million synapses—offers a template for asking how sensory signals become actions across an entire brain.
-    challenge: Connectivity lists paths, not whether those paths transform taste or touch into motor output. Building a whole-brain dynamical model requires neurotransmitter signs and synaptic weights, most of which are predicted or standardized rather than measured cell by cell.
-    action: Shiu, Sterne, Scott, and a large consortium build a leaky integrate-and-fire model of the entire fly brain from FlyWire connectivity and predicted neurotransmitter identity, with a single free synaptic-weight parameter, and they test feeding and grooming circuit predictions with optogenetics, calcium imaging, and behavior (bioRxiv, 2023).
-    resolution: Activating sugar- or water-sensing gustatory neurons in the model predicts taste-responsive cells required for feeding initiation. Predicted feeding-region neurons that drive motor-neuron firing are validated optogenetically. Sugar and water are predicted to share a partial appetitive pathway, confirmed by imaging and behavior. Mechanosensory activation predicts a small antennal-grooming set that does not overlap gustatory circuits. Across 164 empirically tested predictions, 91% were consistent (84% after excluding split-GAL4 experiments in which most types did not elicit MN9 activation).
-    future_work: The authors suggest that more complete transmitter and receptor information and more morphological realism may improve future models, and they conclude that a simple model can describe complete sensorimotor transformations at the complexity of the whole Drosophila brain.
-  plain_language_summary: If you know who is connected to whom in a fly brain, can you guess how tasting sugar leads to eating? This team builds a simple whole-brain spiking model from the wiring diagram, then checks many of its guesses with real fly experiments and reports that most of them hold.
-  summaries:
-    beginner: If you know who is connected to whom in a fly brain, can you guess how tasting sugar leads to eating? This team builds a simple whole-brain spiking model from the wiring diagram, then checks many of its guesses with real fly experiments and reports that most of them hold.
-    intermediate: Posted on bioRxiv (2023), Shiu and colleagues implement a leaky integrate-and-fire whole-brain model using FlyWire synapse counts and predicted transmitters. Membrane parameters are taken from prior Drosophila modeling (for example V_resting = −52 mV, V_threshold = −45 mV); the sole free parameter W_syn = 0.275 mV is set so 100 Hz sugar GRN drive yields about 80% of maximal MN9 firing. The model is applied to gustatory feeding initiation and antennal grooming, with optogenetic and imaging tests. Reported empirical consistency is 91% of 164 predictions (84% in a restricted subset).
-    advanced: This is a preprint of a whole-brain model, not a claim that all FlyWire transmitters are ground truth. W_syn is globally shared, so cell-type differences in synaptic strength are not represented. Accuracy percentages mix many negative “does not activate MN9” results with positive circuit predictions. Morphology is collapsed to point neurons. Overlap of sugar and water pathways is a model prediction confirmed in the authors’ assays, not a unique circuit proof against other formulations. Later published versions may differ in numbers; these figures are from the 2 May 2023 preprint text.
-  discussion_prompts:
-  - What problem in modeling does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2023.05.02.539144.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2023.05.02.539144
-  era: '2023'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: moderate
-  year_cites_percentile: 82
-  streams:
-    axis: pipeline_stage
-    stages:
-    - modeling
-    datasets: []
-    organism:
-    - fly
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: dorkenwald-2020-s41592-021-01330-0
-      title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: marin-2020-2020-01-20-912709
-      title: Connectomics Analysis Reveals First-, Second-, and Third-Order Thermosensory and Hygrosensory Neurons in the Adult Drosophila Brain
-      year: 2020
-    - id: meinertzhagen-2018-jeb-164954
-      title: Of what use is connectomics? A personal perspective on the Drosophila connectome
-      year: 2018
-    - id: schlegel-2020-elife-66018
-      title: Information flow, cell types and stereotypy in a full olfactory connectome
-      year: 2020
-    - id: scheffer-2021-jeb-242740
-      title: A connectome is not enough - what is still needed to understand the brain of Drosophila?
-      year: 2021
-    - id: huang-2018-fninf-2018-00099
-      title: A Single-Cell Level and Connectome-Derived Computational Model of the Drosophila Brain
-      year: 2018
-    cited_by:
-    - id: eckstein-2020-j-cell-2024-03-016
-      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
-      year: 2020
-    - id: joyce-2023-2023-10-20-563359
-      title: A Novel Semi-automated Proofreading and Mesh Error Detection Pipeline for Neuron Extension
-      year: 2023
-    - id: beiran-2024-s41593-025-02080-4
-      title: Prediction of neural activity in connectome-constrained recurrent networks
-      year: 2024
 - id: sizemore-2023-s41467-023-41012-3
   uuid: 10.1038/s41467-023-41012-3
   work_id: work_9f2bd795e155d80b
@@ -26565,9 +26050,9 @@ papers:
     - id: collins-2024-j-crmeth-2025-100988
       title: Comparative prospects of imaging methods for whole-brain mammalian connectomics
       year: 2024
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: schlegel-2024-s41586-024-07686-5
       title: Whole-brain annotation and multi-connectome cell typing of Drosophila
       year: 2024
@@ -27392,90 +26877,6 @@ papers:
     - id: wanner-2020-s41593-019-0576-z
       title: Whitening of odor representations by the wiring diagram of the olfactory bulb
       year: 2020
-    cited_by: []
-- id: wu-2023-arxiv-2302-00545
-  uuid: 10.48550/arxiv.2302.00545
-  work_id: work_6207409da4d43379
-  title: An Out-of-Domain Synapse Detection Challenge for Microwasp Brain Connectomes
-  authors: Jingpeng Wu; Yicong Li; Nishika Gupta; Kazunori Shinomiya; Pat Gunn; A. Polilov; H. Pfister; D. Chklovskii; D. Wei
-  year: 2023
-  journal: arXiv.org
-  doi: 10.48550/arxiv.2302.00545
-  dimension: proofreading
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 7
-  in_degree: 0
-  out_degree: 7
-  annotation_status: generated_from_pdf
-  tags:
-  - synapse detection
-  - domain generalization
-  - megaphragma
-  - electron microscopy
-  - isbi
-  - benchmark
-  - microwasp
-  ocar:
-    opportunity: Connectomics image stacks now reach terabyte to petabyte scale with diverse appearance across regions and samples, so synapse detectors trained on tiny labeled fractions need to generalize out of domain.
-    challenge: Manual synapse annotation is slow, leaving training sets often smaller than 0.001% of test data, and domain-adaptation methods developed for natural images have lacked out-of-domain connectomics benchmarks.
-    action: Wu, Li, Gupta, Shinomiya, Gunn, Polilov, Pfister, Chklovskii, and Wei present an ISBI 2023 challenge paper (arXiv:2302.00545) that annotates 14 image chunks from biologically diverse Megaphragma viggianii brain regions in three whole-brain datasets.
-    resolution: The paper defines a synapse-detection challenge (pre- and postsynaptic points in 3D EM) aimed at pushing out-of-domain generalization methods for large-scale connectomics, analogous in spirit to CREMI but focused on domain shift in a miniature wasp.
-    future_work: The selected extract is a challenge announcement plus author biographies; winning algorithms, leaderboards, and quantitative detector scores are not in this text.
-  plain_language_summary: Computers that find synapses are usually trained on a tiny labeled patch and then asked to work on a huge, differently looking brain. This paper sets up a contest on microwasp volumes so methods can be tested when the training and test images do not match.
-  summaries:
-    beginner: Computers that find synapses are usually trained on a tiny labeled patch and then asked to work on a huge, differently looking brain. This paper sets up a contest on microwasp volumes so methods can be tested when the training and test images do not match.
-    intermediate: On arXiv (2302.00545, February 2023), framed as an ISBI 2023 challenge, Wu and colleagues motivate out-of-domain synapse detection for terabyte-to-petabyte EM. They annotate 14 chunks from diverse brain regions of Megaphragma viggianii across three whole-brain datasets, with presynapses and postsynapses as 3D points. The stated goal is to evaluate domain-adaptation and generalization methods that have been less tested on connectomics for lack of benchmarks. CREMI is cited as a prior in-domain circuit-reconstruction challenge.
-    advanced: This is a challenge description, not a completed method comparison. No algorithm performance numbers appear in the selected extract. The 0.001% training-versus-test figure is the authors’ characterization of typical label scarcity. Organism in the catalog is empty; the PDF specifies the miniature wasp Megaphragma viggianii.
-  discussion_prompts:
-  - What problem in proofreading, synapses does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://arxiv.org/pdf/2302.00545.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.48550/arxiv.2302.00545
-  era: '2023'
-  why: contemporary_keep
-  citation_role: only_out
-  link_strength: moderate
-  year_cites_percentile: 20
-  streams:
-    axis: pipeline_stage
-    stages:
-    - proofreading
-    - synapses
-    datasets: []
-    organism: []
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: xu-2017-elife-25916
-      title: Enhanced FIB-SEM systems for large-volume 3D imaging
-      year: 2017
-    - id: motta-2019-j-conb-2019-03-012
-      title: Big data in nanoscale connectomics, and the greed for training labels.
-      year: 2019
-    - id: shapsoncoe-2021-2021-05-29-446289
-      title: A connectomic study of a petascale fragment of human cerebral cortex
-      year: 2021
-    - id: katz-2019-fncir-2019-00005
-      title: 'DVID: Distributed Versioned Image-Oriented Dataservice'
-      year: 2019
-    - id: turner-2019-isbi45749-2020-90984
-      title: Synaptic Partner Assignment Using Attentional Voxel Association Networks
-      year: 2019
-    - id: bae-2021-s41586-025-08790-w
-      title: Functional connectomics spanning multiple areas of mouse visual cortex
-      year: 2021
-    - id: plaza-2014-j-conb-2014-01-019
-      title: Toward large-scale connectome reconstructions.
-      year: 2014
     cited_by: []
 - id: wu-2023-j-neuron-2023-09-032
   uuid: 10.1016/j.neuron.2023.09.032
@@ -28461,15 +27862,12 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: winding-2022-science-add9330
       title: The connectome of an insect brain
       year: 2022
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: white-1986-rstb-1986-0056
       title: The structure of the nervous system of the nematode Caenorhabditis elegans
       year: 1986
@@ -28746,18 +28144,15 @@ papers:
       title: Reconstruction of motor control circuits in adult Drosophila using automated transmission electron microscopy
       year: 2020
     cited_by:
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: galili-2022-j-cois-2022-100968
       title: Connectomics and the neural basis of behaviour
       year: 2022
     - id: cheong-2026-elife-96084
       title: Organization of circuits linking descending input to motor output in the Drosophila Male Adult Nerve Cord connectome
       year: 2026
-    - id: strner-2025-s41586-025-08925-z
-      title: Comparative connectomics of Drosophila descending and ascending neurons
-      year: 2025
     - id: court-2023-fphys-2023-1076533
       title: Virtual Fly Brain—An interactive atlas of the Drosophila nervous system
       year: 2023
@@ -29093,15 +28488,15 @@ papers:
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -30366,9 +29761,9 @@ papers:
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: pavarino-2023-fncir-2023-952921
       title: 'mEMbrain: an interactive deep learning MATLAB tool for connectomic segmentation on commodity desktops'
       year: 2023
@@ -31359,8 +30754,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: xu-2017-elife-25916
       title: Enhanced FIB-SEM systems for large-volume 3D imaging
@@ -31368,9 +30763,6 @@ papers:
     - id: white-1986-rstb-1986-0056
       title: The structure of the nervous system of the nematode Caenorhabditis elegans
       year: 1986
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: januszewski-2017-s41592-018-0049-4
       title: High-precision automated reconstruction of neurons with flood-filling networks
       year: 2017
@@ -31539,8 +30931,8 @@ papers:
     - id: takemura-2013-nature12450
       title: A visual motion detection circuit suggested by Drosophila connectomics
       year: 2013
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -31788,9 +31180,9 @@ papers:
       title: All-optical visualization of specific molecules in the ultrastructural context of brain tissue
       year: 2022
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
 - id: middlebrooks-2022-j-eplepsyres-2022-10
   uuid: 10.1016/j.eplepsyres.2022.106916
   work_id: work_3ac7168aedad246c
@@ -32009,9 +31401,9 @@ papers:
       title: Synaptic wiring motifs in posterior parietal cortex support decision-making
       year: 2022
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -32353,8 +31745,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: li-2020-elife-62576
       title: The connectome of the adult Drosophila mushroom body provides insights into function
@@ -32368,9 +31760,6 @@ papers:
     - id: zhao-2018-fncir-2018-00101
       title: 'NeuTu: Software for Collaborative, Large-Scale, Segmentation-Based Connectome Reconstruction'
       year: 2018
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: januszewski-2017-s41592-018-0049-4
       title: High-precision automated reconstruction of neurons with flood-filling networks
       year: 2017
@@ -33083,8 +32472,8 @@ papers:
     - id: takemura-2013-nature12450
       title: A visual motion detection circuit suggested by Drosophila connectomics
       year: 2013
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: motta-2019-j-conb-2019-03-012
       title: Big data in nanoscale connectomics, and the greed for training labels.
@@ -33891,9 +33280,9 @@ papers:
     - id: eckstein-2020-j-cell-2024-03-016
       title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
       year: 2020
-    - id: lappalainen-2023-2023-03-11-532232
-      title: Connectome-constrained deep mechanistic networks predict neural responses across the fly visual system at single-neuron resolution
-      year: 2023
+    - id: lappalainen-2024-s41586-024-07939-3
+      title: Connectome-constrained networks predict neural activity across the fly visual system
+      year: 2024
     - id: brown-2026-arxiv-2606-21116
       title: 'ConnectomeBench2: A Unified Benchmark for Automated Connectomic Proofreading'
       year: 2026
@@ -34432,15 +33821,12 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: towlson-2013-jneurosci-3784-12-20
       title: The Rich Club of the C. elegans Neuronal Connectome
       year: 2013
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: takemura-2017-elife-26975
       title: A connectome of a learning and memory center in the adult Drosophila brain
       year: 2017
@@ -34469,9 +33855,9 @@ papers:
     - id: pavarino-2023-fncir-2023-952921
       title: 'mEMbrain: an interactive deep learning MATLAB tool for connectomic segmentation on commodity desktops'
       year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -35535,8 +34921,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
@@ -35566,9 +34952,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -36346,13 +35732,13 @@ papers:
   year: 2021
   journal: Nature
   doi: 10.1038/s41586-021-03284-x
-  dimension: image-acquisition
+  dimension: connectomics
   reading_phase: 2_contemporary
   role: methods
   inclusion_role: contemporary
   k_core: 13
-  in_degree: 33
-  out_degree: 14
+  in_degree: 9
+  out_degree: 11
   annotation_status: generated_from_pdf
   tags:
   - c. elegans
@@ -36426,6 +35812,15 @@ papers:
     - id: varshney-2009-journal-pcbi-1001066
       title: Structural Properties of the Caenorhabditis elegans Neuronal Network
       year: 2009
+    - id: motta-2018-science-aay3134
+      title: Dense connectomic reconstruction in layer 4 of the somatosensory cortex
+      year: 2018
+    - id: cook-2019-s41586-019-1352-7
+      title: Whole-animal connectomes of both Caenorhabditis elegans sexes
+      year: 2019
+    - id: swanson-2016-annurev-neuro-071714
+      title: From Cajal to Connectome and Beyond.
+      year: 2016
     cited_by:
     - id: haber-2023-2023-03-15-532611
       title: The structure and function of neural connectomes are shaped by a small number of design principles
@@ -36451,6 +35846,11 @@ papers:
     - id: emmons-2021-iyab072
       title: Methods for analyzing neuronal structure and activity in Caenorhabditis elegans.
       year: 2021
+    - id: taylor-2020-2020-12-15-422897
+      title: Molecular topography of an entire nervous system
+      year: 2020
+  alt_dois:
+  - 10.1101/2020.05.24.112870
 - id: byrd-2021-j-conb-2021-02-009
   uuid: 10.1016/j.conb.2021.02.009
   work_id: work_4f76473c66f9d125
@@ -37487,84 +36887,6 @@ papers:
     - id: choi-2021-access-2021-3084066
       title: 'ZeVis: A Visual Analytics System for Exploration of a Larval Zebrafish Brain in Serial-Section Electron Microscopy Images'
       year: 2021
-- id: furuta-2021-2021-04-02-438164
-  uuid: 10.1101/2021.04.02.438164
-  work_id: work_2a895c41d7dc42a3
-  title: 'Title: Multi-Scale LM/EM Neuronal Imaging from Brain to Synapse with a Tissue Clearing Method, ScaleSF'
-  authors: T. Furuta; Kenta Yamauchi; Shinichiro Okamoto; Megumu Takahashi; S. Kakuta; Yoko Ishida; Aya Takenaka; Atsushi Yoshida; Y. Uchiyama; Masato Koike; Kaoru Isa; T. Isa; H. Hioki
-  year: 2021
-  journal: bioRxiv
-  doi: 10.1101/2021.04.02.438164
-  dimension: connectomics
-  reading_phase: 2_contemporary
-  role: biology
-  inclusion_role: contemporary
-  k_core: 5
-  in_degree: 0
-  out_degree: 5
-  annotation_status: generated_from_pdf
-  tags:
-  - mouse
-  - marmoset
-  - tissue clearing
-  - correlative lm-em
-  - apex2
-  - callosal
-  - striatum
-  ocar:
-    opportunity: Mammalian circuits span synapses to whole brains, so a single preparation that can be imaged with light and then electron microscopy would let targeted long-range axons be followed to identified synapses.
-    challenge: Volume EM still covers only tens to hundreds of micrometers, while fluorescence can track projections brain-wide but not resolve synaptic ultrastructure in the same volume without destroying it.
-    action: Furuta, Yamauchi, Hioki and colleagues, on bioRxiv (2021), couple successive LM/EM imaging to ScaleSF, an ultrastructure-preserving clearing method, and apply the pipeline to mouse striatofugal, mouse callosal, and marmoset corticostriatal systems with EGFP-APEX2 labeling.
-    resolution: They demonstrate macroscopic, mesoscopic, microscopic, and EM views of the same labeled axons, including TEM of targeted synapses and FIB-SEM of a mouse callosal input onto a PV interneuron, arguing for targeted interrogation of circuit structure and synaptic connectivity together.
-    future_work: The preprint presents the method as a way to expand the spatial scales of objects in brain-wide connectivity studies; how far ScaleSF plus APEX2 generalizes beyond the three demonstrated projections is left open.
-  plain_language_summary: Brain wiring has to be seen both as a whole-brain sketch and as tiny synapses. This team clears tissue in a way that still works for electron microscopy, so they can zoom from a whole slice down to a chosen synapse in mouse and marmoset.
-  summaries:
-    beginner: Brain wiring has to be seen both as a whole-brain sketch and as tiny synapses. This team clears tissue in a way that still works for electron microscopy, so they can zoom from a whole slice down to a chosen synapse in mouse and marmoset.
-    intermediate: Posted on bioRxiv (2021), Furuta, Yamauchi, Hioki and colleagues introduce multi-scale LM/EM imaging with ScaleSF clearing. The workflow runs from brain-wide observation through mesoscopic mapping and subcellular light microscopy to EM of nanoscopic structures. They apply it to mouse striatofugal axons, mouse callosal axons (including inputs onto PV interneurons with FIB-SEM of PSDs), and marmoset corticostriatal projections using AAV SynTetOff EGFP-APEX2 (and a FLEX-mScarlet partner for PV). Figure examples show correlated CLSM, DAB-Ni2+ APEX2 labeling, and TEM of identified synapses.
-    advanced: The selected extract’s later pages are figure legends rather than a limitations section; quantitative clearing metrics, synapse counts, and success rates are not in the usable text. Catalog organism is mouse, but a marmoset corticostriatal example is also demonstrated. This is correlative targeted EM, not a dense connectome. Clearing is ScaleSF specifically, claimed to preserve ultrastructure.
-  discussion_prompts:
-  - What problem in the connectomics pipeline does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/biorxiv/early/2021/04/02/2021.04.02.438164.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2021.04.02.438164
-  era: '2021'
-  why: contemporary_keep
-  citation_role: only_out
-  link_strength: moderate
-  year_cites_percentile: 15
-  streams:
-    axis: biological_application
-    stages: []
-    datasets: []
-    organism:
-    - mouse
-    method:
-    - electron microscopy
-    training_outreach: false
-    health_translation: false
-    biological_application: true
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: holler-2019-s41586-020-03134-2
-      title: Structure and function of a neocortical synapse
-      year: 2019
-    - id: oh-2014-nature13186
-      title: A mesoscale connectome of the mouse brain
-      year: 2014
-    - id: motta-2018-science-aay3134
-      title: Dense connectomic reconstruction in layer 4 of the somatosensory cortex
-      year: 2018
-    - id: lichtman-2008-j-conb-2008-08-010
-      title: 'Ome sweet ome: what can the genome tell us about the connectome?'
-      year: 2008
-    - id: hirabayashi-2017-s41598-018-32820-5
-      title: Correlated Light-Serial Scanning Electron Microscopy (CoLSSEM) for ultrastructural visualization of single neurons in vivo
-      year: 2017
-    cited_by: []
 - id: furuta-2021-j-isci-2021-103601
   uuid: 10.1016/j.isci.2021.103601
   work_id: work_f30031f2d37b416e
@@ -37646,6 +36968,8 @@ papers:
     - id: han-2024-s41467-024-50411-z
       title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
       year: 2024
+  alt_dois:
+  - 10.1101/2021.04.02.438164
 - id: galindo-2021-fninf-2021-753997
   uuid: 10.3389/fninf.2021.753997
   work_id: work_4e83dd54ab62f570
@@ -39483,8 +38807,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: shapsoncoe-2021-2021-05-29-446289
       title: A connectomic study of a petascale fragment of human cerebral cortex
@@ -39508,9 +38832,9 @@ papers:
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: beyer-2022-cgf-14574
       title: A Survey of Visualization and Analysis in High‐Resolution Connectomics
       year: 2022
@@ -39519,9 +38843,6 @@ papers:
       year: 2026
     - id: li-2024-tmi-2024-3400276
       title: 'WASPSYN: A Challenge for Domain Adaptive Synapse Detection in Microwasp Brain Connectomes'
-      year: 2024
-    - id: han-2024-s41467-024-50411-z
-      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
       year: 2024
     - id: wu-2026-2026-06-07-730510
       title: 'FEABAS: A Stitching and Alignment Tool for Serial EM Data'
@@ -39691,15 +39012,12 @@ papers:
     - id: galili-2022-j-cois-2022-100968
       title: Connectomics and the neural basis of behaviour
       year: 2022
-    - id: lappalainen-2023-2023-03-11-532232
-      title: Connectome-constrained deep mechanistic networks predict neural responses across the fly visual system at single-neuron resolution
-      year: 2023
-    - id: wang-2026-fnsys-2026-1822122
-      title: Convergence-divergence circuits for multimodal integration of innate and learned opponent valences
-      year: 2026
     - id: lappalainen-2024-s41586-024-07939-3
       title: Connectome-constrained networks predict neural activity across the fly visual system
       year: 2024
+    - id: wang-2026-fnsys-2026-1822122
+      title: Convergence-divergence circuits for multimodal integration of innate and learned opponent valences
+      year: 2026
     - id: pugliese-2026-2025-09-12-675944
       title: Connectome simulations identify a central pattern generator circuit for fly walking
       year: 2026
@@ -39860,9 +39178,6 @@ papers:
     - id: schneidermizell-2025-s41586-024-07780-8
       title: Inhibitory specificity from a connectomic census of mouse visual cortex
       year: 2025
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: dorkenwald-2024-s41586-024-07558-y
       title: Neuronal wiring diagram of an adult brain
       year: 2024
@@ -40046,9 +39361,6 @@ papers:
     - id: schneidermizell-2025-s41586-024-07780-8
       title: Inhibitory specificity from a connectomic census of mouse visual cortex
       year: 2025
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -40164,9 +39476,6 @@ papers:
     - id: schneidermizell-2025-s41586-024-07780-8
       title: Inhibitory specificity from a connectomic census of mouse visual cortex
       year: 2025
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: bae-2021-s41586-025-08790-w
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
@@ -40328,8 +39637,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -40340,9 +39649,6 @@ papers:
     - id: shapsoncoe-2021-2021-05-29-446289
       title: A connectomic study of a petascale fragment of human cerebral cortex
       year: 2021
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: witvliet-2021-s41586-021-03778-8
       title: Connectomes across development reveal principles of brain maturation
       year: 2021
@@ -41490,8 +40796,8 @@ papers:
     - id: eichler-2017-141762
       title: The complete connectome of a learning and memory centre in an insect brain
       year: 2017
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: white-1986-rstb-1986-0056
       title: The structure of the nervous system of the nematode Caenorhabditis elegans
@@ -41499,9 +40805,6 @@ papers:
     - id: takemura-2017-elife-26975
       title: A connectome of a learning and memory center in the adult Drosophila brain
       year: 2017
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: schlegel-2017-j-cois-2017-09-011
       title: Learning from connectomics on the fly.
       year: 2017
@@ -41512,9 +40815,6 @@ papers:
       title: Information flow, cell types and stereotypy in a full olfactory connectome
       year: 2020
     cited_by:
-    - id: lappalainen-2023-2023-03-11-532232
-      title: Connectome-constrained deep mechanistic networks predict neural responses across the fly visual system at single-neuron resolution
-      year: 2023
     - id: lappalainen-2024-s41586-024-07939-3
       title: Connectome-constrained networks predict neural activity across the fly visual system
       year: 2024
@@ -41524,9 +40824,6 @@ papers:
     - id: shiu-2024-s41586-024-07763-9
       title: A Drosophila computational brain model reveals sensorimotor processing
       year: 2024
-    - id: shiu-2023-2023-05-02-539144
-      title: A leaky integrate-and-fire computational model based on the connectome of the entire adult Drosophila brain reveals insights into sensorimotor processing
-      year: 2023
     - id: mehta-2022-netn-a-00283
       title: Circuit analysis of the Drosophila brain using connectivity-based neuronal classification reveals organization of key communication pathways
       year: 2022
@@ -41687,9 +40984,9 @@ papers:
       title: A mesoscale connectome of the mouse brain
       year: 2014
     cited_by:
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -41806,9 +41103,9 @@ papers:
       title: Anatomy and function of an excitatory network in the visual cortex
       year: 2016
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: haber-2023-2023-03-15-532611
       title: The structure and function of neural connectomes are shaped by a small number of design principles
       year: 2023
@@ -41821,9 +41118,9 @@ papers:
     - id: pavarino-2023-fncir-2023-952921
       title: 'mEMbrain: an interactive deep learning MATLAB tool for connectomic segmentation on commodity desktops'
       year: 2023
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: beyer-2022-cgf-14574
       title: A Survey of Visualization and Analysis in High‐Resolution Connectomics
       year: 2022
@@ -42050,8 +41347,8 @@ papers:
     - id: eichler-2017-141762
       title: The complete connectome of a learning and memory centre in an insect brain
       year: 2017
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: bargmann-2013-nmeth-2451
       title: From the connectome to brain function
@@ -42762,9 +42059,9 @@ papers:
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
 - id: yao-2021-s41593-022-01219-x
   uuid: 10.1038/s41593-022-01219-x
   work_id: work_1f5d00869279e1e0
@@ -43536,8 +42833,8 @@ papers:
     - id: eichler-2017-141762
       title: The complete connectome of a learning and memory centre in an insect brain
       year: 2017
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: bargmann-2013-nmeth-2451
       title: From the connectome to brain function
@@ -43548,9 +42845,6 @@ papers:
     - id: briggman-2011-nature09818
       title: Wiring specificity in the direction-selectivity circuit of the retina
       year: 2011
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: bock-2011-nature09802
       title: Network anatomy and in vivo physiology of visual cortical neurons
       year: 2011
@@ -43819,17 +43113,14 @@ papers:
       title: The wiring diagram of a glomerular olfactory system
       year: 2016
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
       year: 2024
     - id: ashaber-2020-2020-03-09-984013
       title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
-      year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: zheng-2020-2020-04-17-047167
       title: Structured sampling of olfactory input by the fly mushroom body
@@ -43856,8 +43147,8 @@ papers:
   role: methods
   inclusion_role: contemporary
   k_core: 13
-  in_degree: 24
-  out_degree: 10
+  in_degree: 11
+  out_degree: 9
   annotation_status: generated_from_pdf
   tags:
   - natverse
@@ -43933,9 +43224,12 @@ papers:
     - id: berck-2016-037721
       title: The wiring diagram of a glomerular olfactory system
       year: 2016
+    - id: cook-2019-s41586-019-1352-7
+      title: Whole-animal connectomes of both Caenorhabditis elegans sexes
+      year: 2019
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
@@ -43943,21 +43237,29 @@ papers:
     - id: turner-2020-2020-12-11-422105
       title: The connectome predicts resting state functional connectivity across the Drosophila brain
       year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: zheng-2020-2020-04-17-047167
       title: Structured sampling of olfactory input by the fly mushroom body
       year: 2020
     - id: plaza-2022-fninf-2022-896292
       title: 'neuPrint: An open access tool for EM connectomics'
       year: 2022
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
+    - id: clements-2020-2020-01-16-909465
+      title: 'neuPrint: Analysis Tools for EM Connectomics'
+      year: 2020
+    - id: marin-2020-2020-01-20-912709
+      title: Connectomics Analysis Reveals First-, Second-, and Third-Order Thermosensory and Hygrosensory Neurons in the Adult Drosophila Brain
+      year: 2020
+    - id: eckstein-2020-j-cell-2024-03-016
+      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
+      year: 2020
+  alt_dois:
+  - 10.1101/006353
 - id: bayer-2020-elife-59614
   uuid: 10.7554/elife.59614
   work_id: work_20710f84520e8e6f
@@ -44166,88 +43468,6 @@ papers:
     - id: jonaitis-2023-2023-06-21-546011
       title: Stimulus-Specific Modulation is Enabled by Differential Serotonin Receptor Expression
       year: 2023
-- id: brittin-2020-2020-05-24-112870
-  uuid: 10.1101/2020.05.24.112870
-  work_id: work_47dbb1ae5c861feb
-  title: 'Beyond the connectome: A map of a brain architecture derived from whole-brain volumetric reconstructions'
-  authors: C. Brittin; Steven J. Cook; D. Hall; S. W. Emmons; N. Cohen
-  year: 2020
-  journal: bioRxiv
-  doi: 10.1101/2020.05.24.112870
-  dimension: image-acquisition
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 6
-  in_degree: 1
-  out_degree: 5
-  annotation_status: generated_from_pdf
-  tags:
-  - c. elegans
-  - nerve ring
-  - volumetric reconstruction
-  - bundles
-  - connectome variability
-  - residual network
-  ocar:
-    opportunity: C. elegans has a complete synaptic wiring list, but the nerve ring was still treated as a packed axon tract, and small reconstruction samples left invariance versus variability unresolved.
-    challenge: Synaptic maps alone do not locate physical adjacencies or show how morphology, proximity, and synapses jointly constrain computation.
-    action: Brittin, Cook, Hall, Emmons, and Cohen, on bioRxiv (2020), integrate volumetric reconstructions of two nerve rings (young adult and L4) from legacy EM with chemical-synapse and gap-junction connectomes.
-    resolution: They report five functional axon bundles that spatially constrain synapses; a stereotyped core circuit embedded in variable background connectivity, for which they propose a reference connectome; and a four-layer Residual Network architecture in which a residual/feed-forward motif accounts for 77% of C4 synapses, with 4% intra-bundle feedback. Architecture is described as supporting sensory computation, sensory-motor convergence, and brain-wide coordination.
-    future_work: They suggest these modular, residual features are likely universal across phyla; that is a comparative claim not tested outside C. elegans here.
-  plain_language_summary: The worm’s brain was long treated as a tangle of axons with a fixed wiring diagram. By rebuilding two nerve rings in 3D, this team finds five bundles, a stable core plus variable extra connections, and a layered layout that looks a bit like a residual neural network.
-  summaries:
-    beginner: The worm’s brain was long treated as a tangle of axons with a fixed wiring diagram. By rebuilding two nerve rings in 3D, this team finds five bundles, a stable core plus variable extra connections, and a layered layout that looks a bit like a residual neural network.
-    intermediate: 'Posted on bioRxiv (2020), Brittin and colleagues present complete volumetric reconstructions of the C. elegans nerve ring from two animals (young adult and L4), spanning about 36 µm, integrated with synaptic and gap-junction connectomes. They describe five functional bundles, argue the connectome is not invariant, and propose a core reference wiring. A four-layer map is compared to a Residual Network: residual connectivity spanning 77% of C4 synapses, plus 4% intra-bundle feedback, with layer 3 as a recurrent trans-bundle circuit. Figure 4 overlays 82 bilateral pairs and 8 single neurons with reproducible nerve-ring synapses.'
-    advanced: n = 2 animals, so “core versus variable” depends on how reproducibility is thresholded between those two series. “Residual Network” is an analogy to a machine-learning architecture, not a trained model. Universality across phyla is stated as a pointer, not a demonstration. Neighbor definition (physical adjacency in at least one EM section) affects bundle membership. Gap junctions and chemical synapses are both used; the extract does not separate their contributions numerically beyond the 77%/4% figures for the C4 residual map.
-  discussion_prompts:
-  - What problem in preparation, infrastructure does this paper actually solve, and what would falsify that?
-  - How far does this transfer beyond DS01 C. elegans (White+)?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/2020.05.24.112870.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2020.05.24.112870
-  era: '2020'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: moderate
-  year_cites_percentile: 32
-  streams:
-    axis: pipeline_stage
-    stages:
-    - preparation
-    - infrastructure
-    datasets:
-    - DS01 C. elegans (White+)
-    organism:
-    - elegans
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: towlson-2013-jneurosci-3784-12-20
-      title: The Rich Club of the C. elegans Neuronal Connectome
-      year: 2013
-    - id: barabsi-2019-j-neuron-2019-10-031
-      title: A Genetic Model of the Connectome
-      year: 2019
-    - id: motta-2018-science-aay3134
-      title: Dense connectomic reconstruction in layer 4 of the somatosensory cortex
-      year: 2018
-    - id: cook-2019-s41586-019-1352-7
-      title: Whole-animal connectomes of both Caenorhabditis elegans sexes
-      year: 2019
-    - id: swanson-2016-annurev-neuro-071714
-      title: From Cajal to Connectome and Beyond.
-      year: 2016
-    cited_by:
-    - id: taylor-2020-2020-12-15-422897
-      title: Molecular topography of an entire nervous system
-      year: 2020
 - id: cachero-2020-s41592-020-00989-1
   uuid: 10.1038/s41592-020-00989-1
   work_id: work_fb8fe1ff9bb623ea
@@ -44464,9 +43684,9 @@ papers:
     - id: takemura-2017-elife-26975
       title: A connectome of a learning and memory center in the adult Drosophila brain
       year: 2017
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: zhao-2018-fncir-2018-00101
       title: 'NeuTu: Software for Collaborative, Large-Scale, Segmentation-Based Connectome Reconstruction'
       year: 2018
@@ -44483,17 +43703,11 @@ papers:
       title: 'DVID: Distributed Versioned Image-Oriented Dataservice'
       year: 2019
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
-      year: 2020
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: li-2020-elife-62576
       title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: galili-2022-j-cois-2022-100968
       title: Connectomics and the neural basis of behaviour
@@ -44902,8 +44116,8 @@ papers:
     - id: takemura-2013-nature12450
       title: A visual motion detection circuit suggested by Drosophila connectomics
       year: 2013
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: white-1986-rstb-1986-0056
       title: The structure of the nervous system of the nematode Caenorhabditis elegans
@@ -44917,9 +44131,6 @@ papers:
     - id: zhao-2018-fncir-2018-00101
       title: 'NeuTu: Software for Collaborative, Large-Scale, Segmentation-Based Connectome Reconstruction'
       year: 2018
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: januszewski-2017-s41592-018-0049-4
       title: High-precision automated reconstruction of neurons with flood-filling networks
       year: 2017
@@ -44939,9 +44150,6 @@ papers:
     - id: zheng-2020-2020-04-17-047167
       title: Structured sampling of olfactory input by the fly mushroom body
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
@@ -45024,9 +44232,9 @@ papers:
     - id: nuneziglesias-2014-fninf-2014-00034
       title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
       year: 2014
-    - id: johnson-2019-615161
-      title: Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets
-      year: 2019
+    - id: johnson-2020-giaa147
+      title: Toward a scalable framework for reproducible processing of volumetric, nanoscale neuroimaging datasets
+      year: 2020
     cited_by:
     - id: bishop-2021-embc46164-2021-96301
       title: 'CONFIRMS: A Toolkit for Scalable, Black Box Connectome Assessment and Investigation'
@@ -45173,8 +44381,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
@@ -45185,9 +44393,9 @@ papers:
     - id: li-2020-elife-62576
       title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: hulse-2020-2020-12-08-413955
       title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
       year: 2020
@@ -45213,9 +44421,9 @@ papers:
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -45324,7 +44532,7 @@ papers:
   role: methods
   inclusion_role: contemporary
   k_core: 13
-  in_degree: 15
+  in_degree: 8
   out_degree: 3
   annotation_status: generated_from_pdf
   tags:
@@ -45387,8 +44595,8 @@ papers:
       title: The wiring diagram of a glomerular olfactory system
       year: 2016
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
@@ -45399,9 +44607,6 @@ papers:
     - id: ashaber-2020-2020-03-09-984013
       title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
       year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: liu-2021-2021-08-19-456845
       title: Connectomic features underlying diverse synaptic connection strengths and subcellular computation
       year: 2021
@@ -45411,6 +44616,8 @@ papers:
     - id: galili-2022-j-cois-2022-100968
       title: Connectomics and the neural basis of behaviour
       year: 2022
+  alt_dois:
+  - 10.1101/649731
 - id: fenyves-2020-journal-pcbi-1007974
   uuid: 10.1371/journal.pcbi.1007974
   work_id: work_dba0d0b696c23844
@@ -45675,18 +44882,15 @@ papers:
       title: Extracellular space preservation aids the connectomic analysis of neural circuits
       year: 2015
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: svara-2022-s41592-022-01621-0
       title: Automated synapse-level reconstruction of neural circuits in the larval zebrafish brain
       year: 2022
     - id: wildenberg-2021-elife-71981
       title: Partial connectomes of labeled dopaminergic circuits reveal non-synaptic communication and axonal remodeling after exposure to cocaine
       year: 2021
-    - id: han-2024-s41467-024-50411-z
-      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
-      year: 2024
     - id: friedrichsen-2022-fncir-2022-753496
       title: Reconstructing neural circuits using multiresolution correlated light and electron microscopy
       year: 2022
@@ -46486,9 +45690,6 @@ papers:
       title: Fully-Automatic Synapse Prediction and Validation on a Large Data Set
       year: 2016
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
-      year: 2020
     - id: scheffer-2020-elife-57443
       title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
@@ -46577,17 +45778,14 @@ papers:
     - id: eichler-2017-141762
       title: The complete connectome of a learning and memory centre in an insect brain
       year: 2017
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: bargmann-2013-nmeth-2451
       title: From the connectome to brain function
       year: 2013
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: white-1986-rstb-1986-0056
       title: The structure of the nervous system of the nematode Caenorhabditis elegans
@@ -46717,8 +45915,8 @@ papers:
   role: methods
   inclusion_role: contemporary
   k_core: 12
-  in_degree: 2
-  out_degree: 12
+  in_degree: 3
+  out_degree: 9
   annotation_status: generated_from_pdf
   tags:
   - saber
@@ -46790,6 +45988,9 @@ papers:
     - id: roncal-2014-fninf-2015-00020
       title: An automated images-to-graphs framework for high resolution connectomics
       year: 2014
+    - id: nuneziglesias-2014-fninf-2014-00034
+      title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
+      year: 2014
     cited_by:
     - id: bishop-2021-embc46164-2021-96301
       title: 'CONFIRMS: A Toolkit for Scalable, Black Box Connectome Assessment and Investigation'
@@ -46797,6 +45998,11 @@ papers:
     - id: schubert-2022-s41592-022-01624-x
       title: 'SyConn2: dense synaptic connectivity inference for volume electron microscopy'
       year: 2022
+    - id: drenkow-2020-2020-04-30-070755
+      title: Leveraging Tools from Autonomous Navigation for Rapid, Robust Neuron Connectivity
+      year: 2020
+  alt_dois:
+  - 10.1101/615161
 - id: kanari-2020-2020-04-15-040410
   uuid: 10.1101/2020.04.15.040410
   work_id: work_a75ff1aaf09bfb13
@@ -46949,9 +46155,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: wildenberg-2021-elife-71981
       title: Partial connectomes of labeled dopaminergic circuits reveal non-synaptic communication and axonal remodeling after exposure to cocaine
       year: 2021
@@ -47633,110 +46839,6 @@ papers:
     - id: berman-2021-52756d20
       title: 'Bridging the Gap: Point Clouds for Merging Neurons in Connectomics'
       year: 2021
-- id: li-2020-2020-08-29-273276
-  uuid: 10.1101/2020.08.29.273276
-  work_id: work_0c62223b980049c1
-  title: 'The connectome of the adult Drosophila mushroom body: implications for function'
-  authors: Feng Li; Jack W Lindsey; E. Marin; N. Otto; M. Dreher; G. Dempsey; Ildiko Stark; A. S. Bates; M. W. Pleijzier; P. Schlegel; Aljoscha Nern; Shin-ya Takemura; Tansy Yang; Audrey Francis; Amalia Braun; Ruchi Parekh; Marta Costa; Louis K. Scheffer; Yoshinori Aso; G. Jefferis; L. Abbott; Ashok Litwin-Kumar; S. Waddell; G. Rubin
-  year: 2020
-  journal: bioRxiv
-  doi: 10.1101/2020.08.29.273276
-  dimension: connectomics
-  reading_phase: 2_contemporary
-  role: biology
-  inclusion_role: contemporary
-  k_core: 13
-  in_degree: 7
-  out_degree: 14
-  annotation_status: generated_from_pdf
-  tags:
-  - fly
-  - drosophila
-  - mushroom body
-  - learning
-  - dopamine
-  - preprint
-  - hemibrain
-  ocar:
-    opportunity: Synapse-level maps now let researchers infer circuit computations where anatomy, cell types, and behavior already intersect. The adult mushroom body is such a case.
-    challenge: Dense MB connectivity had not been fully interpreted for visual input, descending output, cross-modal structure, DAN modulation, central-complex coupling, and DAN afferents including MBON feedback.
-    action: 'Li, Rubin, and colleagues post a bioRxiv analysis of the adult Drosophila mushroom-body connectome covering the same themes later published in eLife: new components, sensory and DAN structure, output integration, and MB–CX links.'
-    resolution: 'The preprint''s narrative matches the later paper: extensive visual input, MBONs onto descending neurons, structured modality transfer, DAN modulation, and recurrent MBON–DAN motifs illustrated for appetitive memory (for example sugar-responsive DANs depressing odor-specific KC synapses in γ4, γ5, β′2, and β1, with hunger-sensitive MBON11 promoting approach configurations).'
-    future_work: As in the journal version, motifs are hypotheses for experiment. This record is the August 2020 preprint, not a second independent reconstruction.
-  plain_language_summary: 'This preprint is the mushroom-body wiring analysis later published in eLife: a complete look at how the fly learning center is hooked up, including vision, dopamine, and paths out to behavior.'
-  summaries:
-    beginner: 'This preprint is the mushroom-body wiring analysis later published in eLife: a complete look at how the fly learning center is hooked up, including vision, dopamine, and paths out to behavior.'
-    intermediate: On bioRxiv (August 2020), Li, Lindsey, Waddell, Rubin, and colleagues present the adult Drosophila mushroom-body connectome analysis that subsequently appeared in eLife. They highlight visual input, MBONs with descending targets, structured sensory and DAN organization, MB–central-complex connectivity, and MBON feedback onto DANs. Figure-level examples include an appetitive-memory schematic in which sugar-responsive DANs and hunger-sensitive MBON11 reconfigure approach versus avoidance outputs.
-    advanced: This is the same scientific project as the eLife MB paper, not a distinct dataset. Videos referenced in the preprint are not in the selected extract. Circuit diagrams (e.g. Fig. 41) are interpretive overlays on hemibrain connectivity. Prefer the peer-reviewed eLife version for citation unless the preprint-specific record is required.
-  discussion_prompts:
-  - What problem in the connectomics pipeline does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/biorxiv/early/2020/08/29/2020.08.29.273276.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2020.08.29.273276
-  era: '2020'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 66
-  streams:
-    axis: biological_application
-    stages: []
-    datasets: []
-    organism:
-    - fly
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: true
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: eichler-2017-141762
-      title: The complete connectome of a learning and memory centre in an insect brain
-      year: 2017
-    - id: clements-2020-2020-01-16-909465
-      title: 'neuPrint: Analysis Tools for EM Connectomics'
-      year: 2020
-    - id: bargmann-2013-nmeth-2451
-      title: From the connectome to brain function
-      year: 2013
-    - id: takemura-2017-elife-26975
-      title: A connectome of a learning and memory center in the adult Drosophila brain
-      year: 2017
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
-    - id: zheng-2020-2020-04-17-047167
-      title: Structured sampling of olfactory input by the fly mushroom body
-      year: 2020
-    - id: zhao-2018-fncir-2018-00101
-      title: 'NeuTu: Software for Collaborative, Large-Scale, Segmentation-Based Connectome Reconstruction'
-      year: 2018
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
-    cited_by:
-    - id: winding-2022-science-add9330
-      title: The connectome of an insect brain
-      year: 2022
-    - id: hulse-2020-2020-12-08-413955
-      title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
-      year: 2020
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
-    - id: bidel-2022-elife-84257
-      title: Connectomics of the Octopus vulgaris vertical lobe provides insight into conserved and novel principles of a memory acquisition network
-      year: 2022
-    - id: siju-2021-s00441-020-03371-x
-      title: Dopamine modulation of sensory processing and adaptive behavior in flies
-      year: 2021
-    - id: aso-2023-elife-85756
-      title: Neural circuit mechanisms for transforming learned olfactory valences into wind-oriented movement
-      year: 2023
 - id: li-2020-elife-62576
   uuid: 10.7554/elife.62576
   work_id: work_31d1fee6f2ffabfe
@@ -47750,8 +46852,8 @@ papers:
   role: biology
   inclusion_role: contemporary
   k_core: 13
-  in_degree: 62
-  out_degree: 16
+  in_degree: 12
+  out_degree: 9
   annotation_status: generated_from_pdf
   tags:
   - fly
@@ -47822,6 +46924,9 @@ papers:
     - id: scheffer-2020-elife-57443
       title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     cited_by:
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
@@ -47847,6 +46952,20 @@ papers:
     - id: pavarino-2023-fncir-2023-952921
       title: 'mEMbrain: an interactive deep learning MATLAB tool for connectomic segmentation on commodity desktops'
       year: 2023
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
+      year: 2020
+    - id: bidel-2022-elife-84257
+      title: Connectomics of the Octopus vulgaris vertical lobe provides insight into conserved and novel principles of a memory acquisition network
+      year: 2022
+    - id: siju-2021-s00441-020-03371-x
+      title: Dopamine modulation of sensory processing and adaptive behavior in flies
+      year: 2021
+    - id: aso-2023-elife-85756
+      title: Neural circuit mechanisms for transforming learned olfactory valences into wind-oriented movement
+      year: 2023
+  alt_dois:
+  - 10.1101/2020.08.29.273276
 - id: lin-2020-978-3-030-58523-5-7
   uuid: 10.1007/978-3-030-58523-5_7
   work_id: work_6acb043eb4685374
@@ -48279,12 +47398,9 @@ papers:
     - id: takemura-2023-2023-06-05-543757
       title: A Connectome of the Male Drosophila Ventral Nerve Cord
       year: 2023
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -48358,9 +47474,9 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: zheng-2020-2020-04-17-047167
       title: Structured sampling of olfactory input by the fly mushroom body
       year: 2020
@@ -48380,15 +47496,12 @@ papers:
       title: Neural circuit basis of aversive odour processing in Drosophila from sensory input to descending output
       year: 2018
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
       year: 2024
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: scheffer-2020-elife-57443
       title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
@@ -48466,8 +47579,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -49472,8 +48585,8 @@ papers:
   role: methods
   inclusion_role: contemporary
   k_core: 13
-  in_degree: 98
-  out_degree: 16
+  in_degree: 14
+  out_degree: 11
   annotation_status: generated_from_pdf
   tags:
   - fly
@@ -49527,8 +48640,8 @@ papers:
     - id: takemura-2013-nature12450
       title: A visual motion detection circuit suggested by Drosophila connectomics
       year: 2013
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -49548,9 +48661,18 @@ papers:
     - id: hayworth-2015-nmeth-3292
       title: Ultrastructurally-smooth thick partitioning and volume stitching for larger-scale connectomics
       year: 2015
+    - id: lu-2019-855130
+      title: En bloc preparation of Drosophila brains enables high-throughput FIB-SEM connectomics
+      year: 2019
+    - id: huang-2016-fncir-2018-00087
+      title: Fully-Automatic Synapse Prediction and Validation on a Large Data Set
+      year: 2016
+    - id: meinertzhagen-2016-01677063-2016-116622
+      title: 'Connectome studies on Drosophila: a short perspective on a tiny brain'
+      year: 2016
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
@@ -49573,6 +48695,26 @@ papers:
     - id: turner-2020-2020-12-11-422105
       title: The connectome predicts resting state functional connectivity across the Drosophila brain
       year: 2020
+    - id: plaza-2022-fninf-2022-896292
+      title: 'neuPrint: An open access tool for EM connectomics'
+      year: 2022
+    - id: gruber-2025-elife-88824
+      title: The unique synaptic circuitry of specialized olfactory glomeruli in Drosophila melanogaster
+      year: 2025
+    - id: schmidt-2022-s41592-024-02226-5
+      title: 'RoboEM: automated 3D flight tracing for synaptic-resolution connectomics'
+      year: 2022
+    - id: eckstein-2020-j-cell-2024-03-016
+      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
+      year: 2020
+    - id: lin-2021-e619918d
+      title: 'PyTorch Connectomics: A Scalable and Flexible Segmentation Framework for EM Connectomics'
+      year: 2021
+    - id: bae-2021-s41586-025-08790-w
+      title: Functional connectomics spanning multiple areas of mouse visual cortex
+      year: 2021
+  alt_dois:
+  - 10.1101/2020.01.21.911859
 - id: schlegel-2020-elife-66018
   uuid: 10.7554/elife.66018
   work_id: work_d21c268780bf38d6
@@ -49679,9 +48821,9 @@ papers:
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: schlegel-2024-s41586-024-07686-5
       title: Whole-brain annotation and multi-connectome cell typing of Drosophila
       year: 2024
@@ -49813,8 +48955,8 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: holler-2019-s41586-020-03134-2
       title: Structure and function of a neocortical synapse
@@ -50229,9 +49371,6 @@ papers:
     - id: bhattacharya-2018-406207
       title: Plasticity of the electrical connectome of C. elegans
       year: 2018
-    - id: brittin-2020-2020-05-24-112870
-      title: 'Beyond the connectome: A map of a brain architecture derived from whole-brain volumetric reconstructions'
-      year: 2020
     cited_by:
     - id: dvali-2024-6wgv-b9m6
       title: Diverging network architecture of the C. elegans connectome and signaling network
@@ -50529,18 +49668,15 @@ papers:
     - id: winding-2022-science-add9330
       title: The connectome of an insect brain
       year: 2022
-    - id: strner-2024-2024-06-04-596633
-      title: 'Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism'
-      year: 2024
+    - id: strner-2025-s41586-025-08925-z
+      title: Comparative connectomics of Drosophila descending and ascending neurons
+      year: 2025
     - id: galili-2022-j-cois-2022-100968
       title: Connectomics and the neural basis of behaviour
       year: 2022
     - id: lillvis-2022-elife-81248
       title: Rapid reconstruction of neural circuits using tissue expansion and light sheet microscopy
       year: 2022
-    - id: strner-2025-s41586-025-08925-z
-      title: Comparative connectomics of Drosophila descending and ascending neurons
-      year: 2025
     - id: yoo-2023-j-cub-2023-08-020
       title: Brain wiring determinants uncovered by integrating connectomes and transcriptomes.
       year: 2023
@@ -51053,119 +50189,6 @@ papers:
       title: CONNECTOMICS, THE FINAL FRONTIER
       year: 2016
     cited_by: []
-- id: xu-2020-2020-01-21-911859
-  uuid: 10.1101/2020.01.21.911859
-  work_id: work_0c32ed27e86551f0
-  title: A Connectome of the Adult Drosophila Central Brain
-  authors: C. Xu; Michał Januszewski; Zhiyuan Lu; Shin-ya Takemura; K. Hayworth; Gary B. Huang; Kazunori Shinomiya; Jeremy B. Maitin-Shepard; David Ackerman; S. Berg; T. Blakely; J. Bogovic; Jody Clements; Tom Dolafi; Philip M. Hubbard; Dagmar Kainmueller; W. Katz; Takashi Kawase; K. Khairy; Laramie Leavitt; Peter H. Li; Larry F. Lindsey; Nicole L. Neubarth; D. J. Olbris; H. Otsuna; Eric T. Troutman; L. Umayam; Ting Zhao; Masayoshi Ito; Jens Goldammer; T. Wolff; Rob Svirskas; P. Schlegel; Erika Neace; Christopher Knecht; Chelsea X. Alvarado; Dennis Bailey; Samantha Ballinger; J. Borycz; Brandon S Canino; Natasha Cheatham; Michael Cook; M. Dreher; O. Duclos; Bryon Eubanks; K. Fairbanks; Samantha Finley; N. Forknall; Audrey Francis; G. Hopkins; Emily M Joyce; SungJin Kim; Nicole A Kirk; Julie Kovalyak; Shirley A Lauchie; Alanna Lohff; Charli A Maldonado; Emily A Manley; Sari McLin; Caroline Mooney; Miatta Ndama; Omotara Ogundeyi; Nneoma Okeoma; Christopher Ordish; Nicholas Padilla; Christopher Patrick; Tyler Paterson; Elliott Phillips; E. M. Phillips; Neha Rampally; C. Ribeiro; Madelaine K Robertson; J. Rymer; S. Ryan; Megan Sammons; A. K. Scott; Ashley L. Scott; A. Shinomiya; Claire Smith; Kelsey Smith; Natalie Smith; Margaret A. Sobeski; A. Suleiman; Jackie Swift; Satoko Takemura; Iris Talebi; Dorota Tarnogorska; Emily Tenshaw; Temour Tokhi; J. Walsh; Tansy Yang; J. Horne; Feng Li; Ruchi Parekh; P. Rivlin; V. Jayaraman; Kei Ito; S. Saalfeld; R. George; I. Meinertzhagen; G. Rubin; H. Hess; Louis K. Scheffer; Viren Jain; Stephen M. Plaza
-  year: 2020
-  journal: bioRxiv
-  doi: 10.1101/2020.01.21.911859
-  dimension: segmentation
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 13
-  in_degree: 15
-  out_degree: 12
-  annotation_status: generated_from_pdf
-  tags:
-  - fly
-  - drosophila
-  - hemibrain
-  - electron microscopy
-  - proofreading
-  - infrastructure
-  - preprint
-  ocar:
-    opportunity: Complete circuits have been reconstructed in small animals with hundreds of neurons, and selected circuits in larger ones. A dense map of a much more complex brain, with public access, would change how circuit questions are asked.
-    challenge: Imaging, aligning, segmenting, finding synapses, and proofreading at this scale, then defining cell types from connectivity as well as morphology and keeping an evolving dataset usable, had not been demonstrated for a large fraction of the fly central brain.
-    action: Xu, Januszewski, Scheffer, Plaza, and the FlyEM–Google collaboration summarize new methods and present circuitry for a large fraction of the adult Drosophila melanogaster central brain. Proofreading used NeuTu and Neu3, prioritizing fragments that most change connectivity and focusing extra completeness on the central complex and mushroom body. Brain regions were drawn from synapse density, glia, tracts, and wiring.
-    resolution: The preprint announces a public website and resources for exploring an exhaustive cell-type atlas, detailed central-brain circuits, and compartment statistics, aimed at experts and non-specialists. It states that companion papers will treat the hemibrain reconstruction, the central complex, and the mushroom body in more depth.
-    future_work: The note itself defers extensive analysis to those forthcoming papers. Highest completeness is still concentrated in biologically prioritized regions rather than uniformly across the volume.
-  plain_language_summary: This preprint announces a public wiring map of a large part of the adult fruit-fly central brain. It is the methods-and-data release that later companion papers analyze in more biological depth.
-  summaries:
-    beginner: This preprint announces a public wiring map of a large part of the adult fruit-fly central brain. It is the methods-and-data release that later companion papers analyze in more biological depth.
-    intermediate: On bioRxiv (2020), Xu, Januszewski, Scheffer, Plaza, and colleagues (FlyEM at Janelia with Google) present a dense connectome for a large fraction of the adult Drosophila central brain. They describe preparation through proofreading, connectivity-aware cell typing, and region annotation from synapse density, glia, tracts, and wiring. Completeness was pushed first in the central complex and mushroom body. A public site is meant to make partner identity and regional circuitry a lookup; deeper papers on hemibrain, central complex, and mushroom body are promised.
-    advanced: This is a January 2020 announcement preprint, not the later eLife analysis paper. Completeness still varies by region after higher-level proofreading of main branches and stronger pathways. Substructures such as layers and slices in central complex and mushroom body are described as often imprecise for lack of landmarks. Biological interpretation is explicitly deferred.
-  discussion_prompts:
-  - What problem in segmentation, proofreading does this paper actually solve, and what would falsify that?
-  - How far does this transfer beyond DS05 hemibrain?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/biorxiv/early/2020/01/21/2020.01.21.911859.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/2020.01.21.911859
-  era: '2020'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 94
-  streams:
-    axis: pipeline_stage
-    stages:
-    - segmentation
-    - proofreading
-    datasets:
-    - DS05 hemibrain
-    organism:
-    - fly
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: clements-2020-2020-01-16-909465
-      title: 'neuPrint: Analysis Tools for EM Connectomics'
-      year: 2020
-    - id: xu-2017-elife-25916
-      title: Enhanced FIB-SEM systems for large-volume 3D imaging
-      year: 2017
-    - id: takemura-2017-elife-26975
-      title: A connectome of a learning and memory center in the adult Drosophila brain
-      year: 2017
-    - id: katz-2019-fncir-2019-00005
-      title: 'DVID: Distributed Versioned Image-Oriented Dataservice'
-      year: 2019
-    - id: hayworth-2015-nmeth-3292
-      title: Ultrastructurally-smooth thick partitioning and volume stitching for larger-scale connectomics
-      year: 2015
-    - id: lu-2019-855130
-      title: En bloc preparation of Drosophila brains enables high-throughput FIB-SEM connectomics
-      year: 2019
-    - id: huang-2016-fncir-2018-00087
-      title: Fully-Automatic Synapse Prediction and Validation on a Large Data Set
-      year: 2016
-    - id: meinertzhagen-2016-01677063-2016-116622
-      title: 'Connectome studies on Drosophila: a short perspective on a tiny brain'
-      year: 2016
-    cited_by:
-    - id: ashaber-2020-2020-03-09-984013
-      title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
-      year: 2020
-    - id: dorkenwald-2020-s41592-021-01330-0
-      title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: plaza-2022-fninf-2022-896292
-      title: 'neuPrint: An open access tool for EM connectomics'
-      year: 2022
-    - id: gruber-2025-elife-88824
-      title: The unique synaptic circuitry of specialized olfactory glomeruli in Drosophila melanogaster
-      year: 2025
-    - id: schmidt-2022-s41592-024-02226-5
-      title: 'RoboEM: automated 3D flight tracing for synaptic-resolution connectomics'
-      year: 2022
-    - id: eckstein-2020-j-cell-2024-03-016
-      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
-      year: 2020
-    - id: lin-2021-e619918d
-      title: 'PyTorch Connectomics: A Scalable and Flexible Segmentation Framework for EM Connectomics'
-      year: 2021
-    - id: bae-2021-s41586-025-08790-w
-      title: Functional connectomics spanning multiple areas of mouse visual cortex
-      year: 2021
 - id: yuan-2020-brainsci10050314
   uuid: 10.3390/brainsci10050314
   work_id: work_dfec357d43d6ed5e
@@ -51431,8 +50454,8 @@ papers:
       title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
@@ -51443,9 +50466,6 @@ papers:
     - id: dorkenwald-2022-s41592-023-02059-8
       title: Multi-layered maps of neuropil with segmentation-guided contrastive learning
       year: 2022
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
@@ -51880,9 +50900,9 @@ papers:
       title: Conserved neural circuit structure across Drosophila larval development revealed by comparative connectomics
       year: 2017
     cited_by:
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: eckstein-2020-j-cell-2024-03-016
       title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
       year: 2020
@@ -52420,9 +51440,9 @@ papers:
     - id: winding-2022-science-add9330
       title: The connectome of an insect brain
       year: 2022
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: litwinkumar-2019-j-conb-2019-07-007
       title: Constraining computational models using electron microscopy wiring diagrams.
       year: 2019
@@ -52505,78 +51525,6 @@ papers:
     - id: batta-2021-journal-pone-0249846
       title: A weighted network analysis framework for the hourglass effect—And its application in the C. elegans connectome
       year: 2021
-- id: eschbach-2019-649731
-  uuid: 10.1101/649731
-  work_id: work_3167944ed8876ef1
-  title: Multilevel feedback architecture for adaptive regulation of learning in the insect brain
-  authors: Claire Eschbach; Akira Fushiki; Michael Winding; Casey M. Schneider-Mizell; M. Shao; Rebecca Arruda; K. Eichler; Javier Valdes-Aleman; Tomoko Ohyama; Andreas S. Thum; B. Gerber; R. Fetter; J. Truman; Ashok Litwin-Kumar; Albert Cardona; Marta Zlatic
-  year: 2019
-  journal: bioRxiv
-  doi: 10.1101/649731
-  dimension: graph-analysis
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 3
-  in_degree: 0
-  out_degree: 3
-  annotation_status: generated_from_pdf
-  tags:
-  - drosophila larva
-  - mushroom body
-  - dopamine
-  - connectome
-  - feedback
-  - reinforcement learning
-  ocar:
-    opportunity: Modulatory neurons supply teaching signals for associative learning, but the synaptic circuits that compute those signals are poorly mapped. A complete upstream connectome of a compact learning center would show how memories of opposite valence can interact.
-    challenge: How prior memories, context, and opposite-valence compartments jointly set dopaminergic teaching signals remains unclear in both insects and vertebrates.
-    action: Eschbach, Fushiki, Winding, Schneider-Mizell, Shao, Arruda, Eichler, Valdes-Aleman, Ohyama, Thum, Gerber, Fetter, Truman, Litwin-Kumar, Cardona, and Zlatic, on bioRxiv (2019), reconstruct synaptic-resolution circuitry upstream of all modulatory neurons in the Drosophila larval mushroom body, test some pathways functionally, and simulate a connectome-constrained learning model.
-    resolution: They report afferent sensory paths plus 61 feedback neuron pairs providing one- and two-step feedback from mushroom-body output neurons, most linking distinct memory systems. Some modulatory neurons appear to compare inhibition from their own compartment with excitation from opposite-valence compartments. The model indicates that multilevel feedback and cross-compartment connections increase performance and flexibility on learning tasks.
-    future_work: The extract’s discussion treats the map as a basis for circuit implementations of prediction-error and common-currency value; not all 61 pairs are functionally confirmed, and adult mushroom-body generality is not claimed here.
-  plain_language_summary: Learning signals in the fly larva’s memory center are not a simple one-way drip of dopamine. This team maps every incoming synapse onto those signal cells and finds a large web of feedback that lets old memories of good and bad change what is learned next.
-  summaries:
-    beginner: Learning signals in the fly larva’s memory center are not a simple one-way drip of dopamine. This team maps every incoming synapse onto those signal cells and finds a large web of feedback that lets old memories of good and bad change what is learned next.
-    intermediate: Eschbach, Fushiki, Winding, Schneider-Mizell and colleagues (bioRxiv, 2019) present a synaptic-resolution connectome of neurons upstream of all modulatory neurons in the Drosophila larval mushroom body. They report sensory afferents and an unexpected 61 pairs of feedback neurons providing one- and two-step feedback from mushroom-body output neurons, mostly bridging aversive and appetitive compartments. Functional tests indicate that some modulatory neurons combine own-compartment inhibition with opposite-valence excitation. A model constrained by the connectome and those data is used to argue that multilevel feedback and cross-compartment links improve computational performance and flexibility on learning tasks.
-    advanced: This is a bioRxiv preprint (May 2019 posting in the extract), later published in a journal; summaries follow this extract. The ‘first’ claim is the authors’ for this larval MB upstream circuit. The count of 61 feedback neuron pairs is from the abstract. Functional confirmation is partial (‘some’ pathways). Model performance gains are qualitative in the extract (figures 7a–e), not a single accuracy number. EM reconstruction is of the larval mushroom-body teaching circuit, not the whole larval CNS.
-  discussion_prompts:
-  - What problem in graph_analysis does this paper actually solve, and what would falsify that?
-  - How far does this transfer beyond DS03 Drosophila larva?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/649731.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/649731
-  era: '2019'
-  why: contemporary_keep
-  citation_role: only_out
-  link_strength: moderate
-  year_cites_percentile: 31
-  streams:
-    axis: pipeline_stage
-    stages:
-    - graph_analysis
-    datasets:
-    - DS03 Drosophila larva
-    organism:
-    - fly
-    method: []
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: takemura-2017-elife-26975
-      title: A connectome of a learning and memory center in the adult Drosophila brain
-      year: 2017
-    - id: schneidermizell-2015-elife-12059
-      title: Quantitative neuroanatomy for connectomics in Drosophila
-      year: 2015
-    - id: berck-2016-037721
-      title: The wiring diagram of a glomerular olfactory system
-      year: 2016
-    cited_by: []
 - id: funke-2019-tpami-2018-2835450
   uuid: 10.1109/tpami.2018.2835450
   work_id: work_d552830c86eb491f
@@ -52644,9 +51592,9 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: nuneziglesias-2014-fninf-2014-00034
       title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
       year: 2014
@@ -52657,9 +51605,9 @@ papers:
     - id: dorkenwald-2022-s41592-023-02059-8
       title: Multi-layered maps of neuropil with segmentation-guided contrastive learning
       year: 2022
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: wildenberg-2021-elife-71981
       title: Partial connectomes of labeled dopaminergic circuits reveal non-synaptic communication and axonal remodeling after exposure to cocaine
       year: 2021
@@ -53423,97 +52371,6 @@ papers:
     - id: lauenburg-2023-jbhi-2023-3281332
       title: 3D Domain Adaptive Instance Segmentation via Cyclic Segmentation GANs
       year: 2023
-- id: johnson-2019-615161
-  uuid: 10.1101/615161
-  work_id: work_24c9d58c113a2b86
-  title: Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets
-  authors: Erik C. Johnson; Miller Wilt; Luis M. Rodriguez; Raphael Norman-Tenazas; Corban Rivera; Nathan Drenkow; D. Kleissas; Theodore J. LaGrow; Hannah P. Cowley; Joseph Downs; Jordan K. Matelsky; Marisa Hughes; E. Reilly; Brock Andrew Wester; Eva L. Dyer; Konrad Paul Kording; William Gray-Roncal
-  year: 2019
-  journal: bioRxiv
-  doi: 10.1101/615161
-  dimension: infrastructure
-  reading_phase: 2_contemporary
-  role: methods
-  inclusion_role: contemporary
-  k_core: 9
-  in_degree: 1
-  out_degree: 11
-  annotation_status: generated_from_pdf
-  tags:
-  - infrastructure
-  - workflows
-  - saber
-  - electron-microscopy
-  - x-ray-microtomography
-  - reproducibility
-  - containers
-  ocar:
-    opportunity: EM, calcium imaging, and X-ray microtomography now produce gigabyte-to-petabyte structural datasets that could yield synapse-level connectomes and cell maps, but many labs cannot store or process data at that scale.
-    challenge: Existing machine-vision pipelines are often not portable, not scalable, poorly documented, or tied to one hardware stack, so results are hard to reproduce or extend across laboratories and modalities.
-    action: 'Johnson, Wilt, Rodriguez, Norman-Tenazas, Rivera, Drenkow, Kleissas, LaGrow, Cowley, Downs, Matelsky, Hughes, Reilly, Wester, Dyer, Kording, and Gray-Roncal introduce SABER: containerized open-source modules, Common Workflow Language, Apache Airflow (CONDUIT), block-merge execution, and bossDB storage, demonstrated on EM synapse-level connectomes and XRM cell distributions.'
-    resolution: They argue the same standardized modules can be reused across neuroimaging experiments and even other domains. SABER is Apache-2.0 at github.com/aplbrain/saber; demonstration data live in bossDB.
-    future_work: They highlight remaining needs for archive-agnostic I/O as users share pipelines across storage formats, and for cloud (AWS Batch/Kubernetes) versus local execution choices.
-  plain_language_summary: Huge brain pictures are useless if only one lab’s custom computer setup can run the analysis. This paper describes a shared, containerized workflow system so different labs can process large electron-microscope and X-ray brain datasets in a repeatable way.
-  summaries:
-    beginner: Huge brain pictures are useless if only one lab’s custom computer setup can run the analysis. This paper describes a shared, containerized workflow system so different labs can process large electron-microscope and X-ray brain datasets in a repeatable way.
-    intermediate: On bioRxiv (2019), Johnson and colleagues present SABER, a reproducible framework connecting containerized tools, CWL workflow descriptions, Airflow execution, and volumetric storage (bossDB). Exemplars estimate synapse-level connectomes from EM and cell distributions from X-ray microtomography. They compare SABER with CWL-Airflow, Toil, Galaxy, and Air-tasks, emphasizing neuroimaging-specific block-merge and workflow optimization. Code is at github.com/aplbrain/saber under Apache 2.0.
-    advanced: This is a framework preprint, not a new biological connectome. No quantitative reconstruction accuracy for the EM/XRM exemplars appears in the selected text. Catalog tags infrastructure, graph_analysis, and electron microscopy; organism is unspecified.
-  discussion_prompts:
-  - What problem in infrastructure, graph_analysis does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/biorxiv/early/2019/04/22/615161.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/615161
-  era: '2019'
-  why: contemporary_keep
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 28
-  streams:
-    axis: pipeline_stage
-    stages:
-    - infrastructure
-    - graph_analysis
-    datasets: []
-    organism: []
-    method:
-    - electron microscopy
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: takemura-2013-nature12450
-      title: A visual motion detection circuit suggested by Drosophila connectomics
-      year: 2013
-    - id: lee-2016-nature17192
-      title: Anatomy and function of an excitatory network in the visual cortex
-      year: 2016
-    - id: staffler-2017-elife-26414
-      title: SynEM, automated synapse detection for connectomics
-      year: 2017
-    - id: kasthuri-2015-j-cell-2015-06-054
-      title: Saturated Reconstruction of a Volume of Neocortex
-      year: 2015
-    - id: knowlesbarley-2016-7383d513
-      title: 'RhoanaNet Pipeline: Dense Automatic Neural Annotation'
-      year: 2016
-    - id: lichtman-2014-nn-3837
-      title: The big data challenges of connectomics
-      year: 2014
-    - id: roncal-2014-fninf-2015-00020
-      title: An automated images-to-graphs framework for high resolution connectomics
-      year: 2014
-    - id: nuneziglesias-2014-fninf-2014-00034
-      title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
-      year: 2014
-    cited_by:
-    - id: drenkow-2020-2020-04-30-070755
-      title: Leveraging Tools from Autonomous Navigation for Rapid, Robust Neuron Connectivity
-      year: 2020
 - id: karagiannis-2019-829903
   uuid: 10.1101/829903
   work_id: work_6e6d74dd4f3c6069
@@ -53744,24 +52601,21 @@ papers:
       title: NeuroBlocks – Visual Tracking of Segmentation and Proofreading for Large Connectomics Projects
       year: 2016
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
       year: 2020
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: plaza-2022-fninf-2022-896292
       title: 'neuPrint: An open access tool for EM connectomics'
       year: 2022
     - id: beyer-2022-cgf-14574
       title: A Survey of Visualization and Analysis in High‐Resolution Connectomics
       year: 2022
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: lee-2019-j-conb-2019-04-001
       title: Convolutional nets for reconstructing neural circuits from brain images acquired by serial section electron microscopy
       year: 2019
@@ -54471,9 +53325,9 @@ papers:
     - id: funke-2019-tpami-2018-2835450
       title: Large Scale Image Segmentation with Structured Loss Based Deep Learning for Connectome Reconstruction
       year: 2019
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: matejek-2019-cvpr-2019-00219
       title: Biologically-Constrained Graphs for Global Connectomics Reconstruction
       year: 2019
@@ -54752,15 +53606,12 @@ papers:
       title: Ultrastructurally-smooth thick partitioning and volume stitching for larger-scale connectomics
       year: 2015
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: takemura-2023-2023-06-05-543757
       title: A Connectome of the Male Drosophila Ventral Nerve Cord
       year: 2023
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: liao-2023-arxiv-2312-14518
       title: Joint Learning Neuronal Skeleton and Brain Circuit Topology with Permutation Invariant Encoders for Neuron Classification
       year: 2023
@@ -55009,9 +53860,9 @@ papers:
     - id: knowlesbarley-2016-7383d513
       title: 'RhoanaNet Pipeline: Dense Automatic Neural Annotation'
       year: 2016
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: haehn-2017-informatics4030029
       title: Scalable Interactive Visualization for Connectomics
       year: 2017
@@ -55219,9 +54070,6 @@ papers:
     - id: goldt-2021-journal-pcbi-1010813
       title: Bayesian reconstruction of memories stored in neural networks from their connectivity
       year: 2021
-    - id: wu-2023-arxiv-2302-00545
-      title: An Out-of-Domain Synapse Detection Challenge for Microwasp Brain Connectomes
-      year: 2023
     - id: collins-2026-2a3e58a1
       title: 'A First Step for Expansion X-Ray Microscopy: Achieving Contrast in Expanded Tissues Sufficient to Reveal Cell Bodies'
       year: 2026
@@ -57110,9 +55958,6 @@ papers:
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
       year: 2025
@@ -57655,15 +56500,12 @@ papers:
       title: 'Connectome studies on Drosophila: a short perspective on a tiny brain'
       year: 2016
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: collins-2024-j-crmeth-2025-100988
       title: Comparative prospects of imaging methods for whole-brain mammalian connectomics
       year: 2024
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: galili-2022-j-cois-2022-100968
       title: Connectomics and the neural basis of behaviour
       year: 2022
@@ -57777,9 +56619,6 @@ papers:
     - id: collins-2024-j-crmeth-2025-100988
       title: Comparative prospects of imaging methods for whole-brain mammalian connectomics
       year: 2024
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: karlupia-2023-j-biopsych-2023-01-0
       title: Immersion fixation and staining of multi-cubic millimeter volumes for electron microscopy-based connectomics of human brain biopsies
       year: 2023
@@ -58096,9 +56935,6 @@ papers:
       title: A genetically specified connectomics approach applied to long-range feeding regulatory circuits
       year: 2014
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
     - id: han-2024-s41467-024-50411-z
       title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
       year: 2024
@@ -58512,9 +57348,9 @@ papers:
       title: NeuroBlocks – Visual Tracking of Segmentation and Proofreading for Large Connectomics Projects
       year: 2016
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -58796,9 +57632,9 @@ papers:
     - id: huang-2016-fncir-2018-00087
       title: Fully-Automatic Synapse Prediction and Validation on a Large Data Set
       year: 2016
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     cited_by:
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
@@ -60262,9 +59098,9 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     cited_by:
     - id: dorkenwald-2025-s41592-024-02426-z
       title: 'CAVE: Connectome Annotation Versioning Engine'
@@ -60734,9 +59570,6 @@ papers:
     - id: shiu-2024-s41586-024-07763-9
       title: A Drosophila computational brain model reveals sensorimotor processing
       year: 2024
-    - id: shiu-2023-2023-05-02-539144
-      title: A leaky integrate-and-fire computational model based on the connectome of the entire adult Drosophila brain reveals insights into sensorimotor processing
-      year: 2023
     - id: lazar-2021-2021-12-28-474399
       title: A Programmable Ontology Encompassing the Functional Logic of the Drosophila Brain
       year: 2021
@@ -61089,9 +59922,6 @@ papers:
       title: As-rigid-as-possible mosaicking and serial section registration of large ssTEM datasets
       year: 2010
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
-      year: 2020
     - id: scheffer-2020-elife-57443
       title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
@@ -61695,9 +60525,9 @@ papers:
       title: Crowdsourcing the creation of image segmentation algorithms for connectomics
       year: 2015
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: dorkenwald-2022-s41592-023-02059-8
       title: Multi-layered maps of neuropil with segmentation-guided contrastive learning
       year: 2022
@@ -61719,88 +60549,6 @@ papers:
     - id: bidel-2022-elife-84257
       title: Connectomics of the Octopus vulgaris vertical lobe provides insight into conserved and novel principles of a memory acquisition network
       year: 2022
-- id: miroschnikow-2018-368878
-  uuid: 10.1101/368878
-  work_id: work_caded82b4ff6f38b
-  title: 'The Feeding Connectome: Convergence of Monosynaptic and Polysynaptic Sensory Paths onto Common Motor Outputs'
-  authors: Anton Miroschnikow; P. Schlegel; Andreas Schoofs; Sebastian Hueckesfeld; Feng Li; C. Schneider-Mizell; R. Fetter; J. Truman; Albert Cardona; M. Pankratz
-  year: 2018
-  journal: bioRxiv
-  doi: 10.1101/368878
-  dimension: connectomics
-  reading_phase: 1_foundations
-  role: survey
-  inclusion_role: history
-  k_core: 6
-  in_degree: 0
-  out_degree: 6
-  annotation_status: generated_from_pdf
-  tags:
-  - drosophila larva
-  - feeding
-  - electron microscopy
-  - sensory-motor
-  - sez
-  - mushroom body
-  - neuroendocrine
-  ocar:
-    opportunity: How external and internal sensory inputs select among possible motor and neuroendocrine paths is a basic problem in circuit organization, and Drosophila larva feeding is tractable for whole-CNS synaptic mapping plus behavior.
-    challenge: Synaptic-resolution maps of entire nervous systems remain rare, so the central architecture that routes enteric, pharyngeal, and external sensory input onto feeding motor and endocrine outputs was largely unknown.
-    action: Miroschnikow, Schlegel, Schoofs, Hückesfeld, Li, Schneider-Mizell, Fetter, Truman, Cardona, and Pankratz reconstruct from a whole-CNS electron-microscopy volume the synaptic map of input and output neurons that underlie larval food intake, posted on bioRxiv (2018).
-    resolution: Sensory axons converge onto seven topographic synaptic compartments in the subesophageal zone. Monosynaptic connections, mostly enteric, cover overlapping motor and endocrine targets and form an elemental feeding circuit, while distinct polysynaptic routes overlay that reflex arc; a different set of compartments innervates the mushroom-body calyx.
-    future_work: The authors analogize sparse somatosensory monosynaptic reflexes to C. elegans head (versus body) circuits and cite unpublished ventral-nerve-cord data; they frame the architecture as a template for feeding reflexes and other instinctive behaviors rather than a completed functional census.
-  plain_language_summary: This team traces feeding-related neurons in a fruit-fly larva brain from electron-microscope pictures. Direct sensory-to-motor shortcuts and longer multi-step paths both land on the same swallowing and hormone-output cells.
-  summaries:
-    beginner: This team traces feeding-related neurons in a fruit-fly larva brain from electron-microscope pictures. Direct sensory-to-motor shortcuts and longer multi-step paths both land on the same swallowing and hormone-output cells.
-    intermediate: Posted on bioRxiv (2018), Miroschnikow and colleagues reconstruct a synaptic feeding connectome from a Drosophila larva whole-CNS EM volume. Enteric, pharyngeal, and external sensory neurons terminate in seven presynaptic compartments of the subesophageal zone, a region they compare to the vertebrate brainstem. Outputs include pharyngeal motor neurons, serotonergic modulators, and neuroendocrine cells targeting the ring gland. Most monosynaptic links are enteric and cannot be subdivided further; somatosensory monosynaptic reflexes onto mouth-hook and head-tilt motor neurons are few. A separate sensory set reaches the mushroom-body calyx.
-    advanced: The selected extract is a July 2018 bioRxiv preprint, not a later journal version. “Vast majority” of elemental-circuit inputs are described as enteric without a count in this extract. The claim of fewer monosynaptic reflexes in the larval VNC is explicitly unpublished (Ohyama et al., 2015). Functional assignment of compartments is anatomical (modality and peripheral origin), not a full activity map.
-  discussion_prompts:
-  - What problem in the connectomics pipeline does this paper actually solve, and what would falsify that?
-  - How far does this transfer beyond DS03 Drosophila larva?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/10.1101/368878.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/368878
-  era: 2016–2018
-  why: history_milestone
-  citation_role: only_out
-  link_strength: moderate
-  year_cites_percentile: 7
-  streams:
-    axis: registry_dataset
-    stages: []
-    datasets:
-    - DS03 Drosophila larva
-    organism:
-    - fly
-    method:
-    - electron microscopy
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: schlegel-2017-j-cois-2017-09-011
-      title: Learning from connectomics on the fly.
-      year: 2017
-    - id: schneidermizell-2015-elife-12059
-      title: Quantitative neuroanatomy for connectomics in Drosophila
-      year: 2015
-    - id: berck-2016-037721
-      title: The wiring diagram of a glomerular olfactory system
-      year: 2016
-    - id: gerhard-2017-143727
-      title: Conserved neural circuit structure across Drosophila larval development revealed by comparative connectomics
-      year: 2017
-    - id: swanson-2016-annurev-neuro-071714
-      title: From Cajal to Connectome and Beyond.
-      year: 2016
-    - id: williams-2017-elife-26349
-      title: Synaptic and peptidergic connectome of a neurosecretory center in the annelid brain
-      year: 2017
-    cited_by: []
 - id: miroschnikow-2018-elife-40247
   uuid: 10.7554/elife.40247
   work_id: work_2e89582f1e165cd3
@@ -61814,7 +60562,7 @@ papers:
   role: survey
   inclusion_role: history
   k_core: 12
-  in_degree: 8
+  in_degree: 7
   out_degree: 6
   annotation_status: generated_from_pdf
   tags:
@@ -61904,6 +60652,8 @@ papers:
     - id: hckesfeld-2021-elife-65745
       title: Unveiling the sensory and interneuronal pathways of the neuroendocrine connectome in Drosophila
       year: 2021
+  alt_dois:
+  - 10.1101/368878
 - id: motta-2018-science-aay3134
   uuid: 10.1126/science.aay3134
   work_id: work_c6b4755fa98e0894
@@ -62279,9 +61029,9 @@ papers:
     - id: huang-2016-fncir-2018-00087
       title: Fully-Automatic Synapse Prediction and Validation on a Large Data Set
       year: 2016
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: plaza-2014-33ec5350
       title: Annotating Synapses in Large EM Datasets
       year: 2014
@@ -64781,8 +63531,8 @@ papers:
       title: Design and Evaluation of Interactive Proofreading Tools for Connectomics
       year: 2014
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -64792,9 +63542,6 @@ papers:
       year: 2024
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: hulse-2020-2020-12-08-413955
       title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
@@ -65783,8 +64530,8 @@ papers:
       title: The wiring diagram of a glomerular olfactory system
       year: 2016
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: shuai-2024-2023-09-15-557808
       title: Driver lines for studying associative learning in Drosophila
@@ -65794,9 +64541,6 @@ papers:
       year: 2020
     - id: turner-2020-2020-12-11-422105
       title: The connectome predicts resting state functional connectivity across the Drosophila brain
-      year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: hulse-2020-2020-12-08-413955
       title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
@@ -66003,9 +64747,9 @@ papers:
     field_synthesis: false
   related:
     cites:
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: nuneziglesias-2014-fninf-2014-00034
       title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
       year: 2014
@@ -66530,9 +65274,6 @@ papers:
     - id: furuta-2021-j-isci-2021-103601
       title: Multi-scale light microscopy/electron microscopy neuronal imaging from brain to synapse with a tissue clearing method, ScaleSF
       year: 2021
-    - id: furuta-2021-2021-04-02-438164
-      title: 'Title: Multi-Scale LM/EM Neuronal Imaging from Brain to Synapse with a Tissue Clearing Method, ScaleSF'
-      year: 2021
     - id: ohno-2024-j-neures-2024-06-002
       title: Volume Electron Microscopy for Genetically and Molecularly Defined Neural Circuits.
       year: 2024
@@ -66683,8 +65424,8 @@ papers:
   role: methods
   inclusion_role: history
   k_core: 13
-  in_degree: 60
-  out_degree: 5
+  in_degree: 16
+  out_degree: 7
   annotation_status: generated_from_pdf
   tags:
   - flood-filling-networks
@@ -66754,6 +65495,12 @@ papers:
     - id: funke-2017-90335d75
       title: A Deep Structured Learning Approach Towards Automating Connectome Reconstruction from 3D Electron Micrographs
       year: 2017
+    - id: helmstaedter-2011-nn-2868
+      title: High-accuracy neurite reconstruction for high-throughput neuroanatomy
+      year: 2011
+    - id: zlateski-2015-c04d1dc3
+      title: Image Segmentation by Size-Dependent Single Linkage Clustering of a Watershed Basin Graph
+      year: 2015
     cited_by:
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -66761,9 +65508,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -66779,6 +65526,32 @@ papers:
     - id: plaza-2022-fninf-2022-896292
       title: 'neuPrint: An open access tool for EM connectomics'
       year: 2022
+    - id: zheng-2017-j-cell-2018-06-019
+      title: A Complete Electron Microscopy Volume of the Brain of Adult Drosophila melanogaster
+      year: 2017
+    - id: meinertzhagen-2018-jeb-164954
+      title: Of what use is connectomics? A personal perspective on the Drosophila connectome
+      year: 2018
+    - id: schlegel-2017-j-cois-2017-09-011
+      title: Learning from connectomics on the fly.
+      year: 2017
+    - id: zung-2017-341de8b6
+      title: An Error Detection and Correction Framework for Connectomics
+      year: 2017
+    - id: turner-2019-isbi45749-2020-90984
+      title: Synaptic Partner Assignment Using Attentional Voxel Association Networks
+      year: 2019
+    - id: funke-2019-tpami-2018-2835450
+      title: Large Scale Image Segmentation with Structured Loss Based Deep Learning for Connectome Reconstruction
+      year: 2019
+    - id: eberle-2018-fnana-2018-00112
+      title: Multi-Beam Scanning Electron Microscopy for High-Throughput Imaging in Connectomics Research
+      year: 2018
+    - id: kievits-2022-jmi-13134
+      title: How innovations in methodology offer new prospects for volume electron microscopy
+      year: 2022
+  alt_dois:
+  - work_3de0825b6d9efa49
 - id: kaiser-2017-j-tics-2017-05-010
   uuid: 10.1016/j.tics.2017.05.010
   work_id: work_61b9f3ef5f831055
@@ -67150,9 +65923,9 @@ papers:
     - id: helmstaedter-2011-nn-2868
       title: High-accuracy neurite reconstruction for high-throughput neuroanatomy
       year: 2011
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: jiang-2015-science-aac9462
       title: Principles of connectivity among morphologically defined cell types in adult neocortex
       year: 2015
@@ -67552,9 +66325,6 @@ papers:
   related:
     cites: []
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
-      year: 2020
     - id: li-2020-elife-62576
       title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
@@ -67683,9 +66453,6 @@ papers:
       year: 2017
     - id: lee-2019-tmi-2021-3097826
       title: Learning and Segmenting Dense Voxel Embeddings for 3D Neuron Reconstruction
-      year: 2019
-    - id: johnson-2019-615161
-      title: Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets
       year: 2019
 - id: michels-2017-fnbeh-2017-00045
   uuid: 10.3389/fnbeh.2017.00045
@@ -68293,9 +67060,9 @@ papers:
     - id: santurkar-2017-5c63a03f
       title: Toward Streaming Synapse Detection with Compositional ConvNets
       year: 2017
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: matveev-2017-3018743-3018766
       title: A Multicore Path to Connectomics-on-Demand
       year: 2017
@@ -68515,9 +67282,9 @@ papers:
       title: 'webKnossos: efficient online 3D data annotation for connectomics'
       year: 2017
     cited_by:
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: hulse-2020-2020-12-08-413955
       title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
       year: 2020
@@ -68536,9 +67303,6 @@ papers:
     - id: heinrich-2018-978-3-030-00934-2-36
       title: Synaptic Cleft Segmentation in Non-Isotropic Volume Electron Microscopy of the Complete Drosophila Brain
       year: 2018
-    - id: bates-2020-elife-53350
-      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
-      year: 2020
 - id: schrter-2017-nrn-2016-182
   uuid: 10.1038/nrn.2016.182
   work_id: work_f144bf9a5935462c
@@ -69094,11 +67858,11 @@ papers:
     - id: eichler-2017-141762
       title: The complete connectome of a learning and memory centre in an insect brain
       year: 2017
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -69112,9 +67876,6 @@ papers:
     - id: winding-2022-science-add9330
       title: The connectome of an insect brain
       year: 2022
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
-      year: 2020
 - id: tang-2017-10618600-2016-119350
   uuid: 10.1080/10618600.2016.1193505
   work_id: work_3cf5d4c3be86004c
@@ -69588,8 +68349,8 @@ papers:
       title: 'Focused Proofreading: Efficiently Extracting Connectomes from Segmented EM Images'
       year: 2014
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: motta-2019-j-conb-2019-03-012
       title: Big data in nanoscale connectomics, and the greed for training labels.
@@ -69600,9 +68361,6 @@ papers:
     - id: zhao-2018-fncir-2018-00101
       title: 'NeuTu: Software for Collaborative, Large-Scale, Segmentation-Based Connectome Reconstruction'
       year: 2018
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: wildenberg-2021-elife-71981
       title: Partial connectomes of labeled dopaminergic circuits reveal non-synaptic communication and axonal remodeling after exposure to cocaine
       year: 2021
@@ -69828,12 +68586,12 @@ papers:
     - id: wetzel-2016-aipr-2016-8010595
       title: Registering large volume serial-section electron microscopy image sets for neural circuit reconstruction using FFT signal whitening
       year: 2016
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: clements-2020-2020-01-16-909465
       title: 'neuPrint: Analysis Tools for EM Connectomics'
@@ -69852,9 +68610,6 @@ papers:
       year: 2024
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
-      year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
 - id: zung-2017-341de8b6
   uuid: work_ad4d87e6341de8b6
@@ -69932,9 +68687,6 @@ papers:
     - id: argandacarreras-2015-fnana-2015-00142
       title: Crowdsourcing the creation of image segmentation algorithms for connectomics
       year: 2015
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
     - id: nuneziglesias-2014-fninf-2014-00034
       title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
       year: 2014
@@ -70390,9 +69142,9 @@ papers:
     - id: winding-2022-science-add9330
       title: The connectome of an insect brain
       year: 2022
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: litwinkumar-2019-j-conb-2019-07-007
       title: Constraining computational models using electron microscopy wiring diagrams.
       year: 2019
@@ -70807,9 +69559,6 @@ papers:
     - id: johnson-2020-giaa147
       title: Toward a scalable framework for reproducible processing of volumetric, nanoscale neuroimaging datasets
       year: 2020
-    - id: johnson-2019-615161
-      title: Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets
-      year: 2019
 - id: economo-2016-elife-10566
   uuid: 10.7554/elife.10566
   work_id: work_e00a7fb6feedbf91
@@ -71441,8 +70190,8 @@ papers:
       title: Annotating Synapses in Large EM Datasets
       year: 2014
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
@@ -71453,9 +70202,6 @@ papers:
     - id: dorkenwald-2017-nmeth-4206
       title: Automated synaptic connectivity inference for volume electron microscopy
       year: 2017
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: staffler-2017-elife-26414
       title: SynEM, automated synapse detection for connectomics
       year: 2017
@@ -71465,102 +70211,6 @@ papers:
     - id: lee-2019-j-conb-2019-04-001
       title: Convolutional nets for reconstructing neural circuits from brain images acquired by serial section electron microscopy
       year: 2019
-- id: januszewski-2016-6d9efa49
-  uuid: work_3de0825b6d9efa49
-  work_id: work_3de0825b6d9efa49
-  title: Flood-Filling Networks
-  authors: Michał Januszewski; Jeremy B. Maitin-Shepard; Peter H. Li; J. Kornfeld; W. Denk; Viren Jain
-  year: 2016
-  journal: arXiv.org
-  doi: ''
-  dimension: segmentation
-  reading_phase: 1_foundations
-  role: methods
-  inclusion_role: history
-  k_core: 12
-  in_degree: 21
-  out_degree: 3
-  annotation_status: generated_from_pdf
-  tags:
-  - flood-filling networks
-  - segmentation
-  - electron microscopy
-  - recurrent cnn
-  - volume em
-  ocar:
-    opportunity: Standard EM neuron segmentation splits boundary detection from watershed-style grouping, so the learned step never directly optimizes object identity. An end-to-end recurrent net that grows one segment at a time could replace that pipeline.
-    challenge: Object number and size vary wildly in neuropil. Inference cost scales with volume and with how many objects sit in the field of view, and overlapping fields of view reprocess voxels. Movement of the field of view during training and inference is still heuristic.
-    action: 'Januszewski, Maitin-Shepard, Li, Kornfeld, Denk, and Jain introduce flood-filling networks on arXiv (2016): a recurrent 3D convolutional net that iteratively fills individual segments from raw EM, demonstrated on connectomic volume EM.'
-    resolution: They report substantial accuracy gains over other contemporary methods on a challenging 3D EM reconstruction task and argue FFNs can replace multi-step pipelines with one end-to-end network. On a densely skeletonized subvolume, FFN inference cost is 4.6 PFLOP versus about 0.14 PFLOP for a 3D affinity-graph CNN; typically 2–3 objects occupy the field of view, and voxels are processed multiple times (42–75% FoV overlap).
-    future_work: They outline cheaper architectures (U-Net-like bottlenecks, strided convs, larger steps, split mask/image branches), ultrastructure-aware training, better handling of extremely thin processes, and a learned FoV-movement policy.
-  plain_language_summary: Usual computer programs first find cell edges and then flood-fill the insides as a separate step. This network grows each cell from the raw 3D picture in one learned loop, aiming to trace tangled brain wires more accurately.
-  summaries:
-    beginner: Usual computer programs first find cell edges and then flood-fill the insides as a separate step. This network grows each cell from the raw 3D picture in one learned loop, aiming to trace tangled brain wires more accurately.
-    intermediate: 'Januszewski et al. (arXiv 2016) present flood-filling networks: a recurrent 3D CNN that emits one object at a time from raw EM. They report large accuracy gains versus then-standard boundary-plus-watershed pipelines on connectomic data. Compute is higher (4.6 vs 0.14 PFLOP on one subvolume) because multiple overlapping passes visit each object.'
-    advanced: This preprint predates the 2018 Nature Methods FFN paper; headline path-length numbers from that later paper are not in this extract and are not used. 'Substantially improve accuracy' is not given as a named metric here. Cost figures are for one densely skeletonized subvolume. FoV movement remains heuristic in this version.
-  discussion_prompts:
-  - What problem in segmentation, acquisition does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://arxiv.org/pdf/1611.00421.pdf
-  pdf_status: downloaded
-  landing_url: https://arxiv.org/abs/1611.00421
-  era: 2016–2018
-  why: history_milestone
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 59
-  streams:
-    axis: pipeline_stage
-    stages:
-    - segmentation
-    - acquisition
-    datasets: []
-    organism: []
-    method:
-    - Flood-filling networks
-    - volume EM
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: helmstaedter-2011-nn-2868
-      title: High-accuracy neurite reconstruction for high-throughput neuroanatomy
-      year: 2011
-    - id: nuneziglesias-2014-fninf-2014-00034
-      title: 'Graph-based active learning of agglomeration (GALA): a Python library to segment 2D and 3D neuroimages'
-      year: 2014
-    - id: zlateski-2015-c04d1dc3
-      title: Image Segmentation by Size-Dependent Single Linkage Clustering of a Watershed Basin Graph
-      year: 2015
-    cited_by:
-    - id: zheng-2017-j-cell-2018-06-019
-      title: A Complete Electron Microscopy Volume of the Brain of Adult Drosophila melanogaster
-      year: 2017
-    - id: meinertzhagen-2018-jeb-164954
-      title: Of what use is connectomics? A personal perspective on the Drosophila connectome
-      year: 2018
-    - id: schlegel-2017-j-cois-2017-09-011
-      title: Learning from connectomics on the fly.
-      year: 2017
-    - id: zung-2017-341de8b6
-      title: An Error Detection and Correction Framework for Connectomics
-      year: 2017
-    - id: turner-2019-isbi45749-2020-90984
-      title: Synaptic Partner Assignment Using Attentional Voxel Association Networks
-      year: 2019
-    - id: funke-2019-tpami-2018-2835450
-      title: Large Scale Image Segmentation with Structured Loss Based Deep Learning for Connectome Reconstruction
-      year: 2019
-    - id: eberle-2018-fnana-2018-00112
-      title: Multi-Beam Scanning Electron Microscopy for High-Throughput Imaging in Connectomics Research
-      year: 2018
-    - id: kievits-2022-jmi-13134
-      title: How innovations in methodology offer new prospects for volume electron microscopy
-      year: 2022
 - id: joesch-2016-elife-15015
   uuid: 10.7554/elife.15015
   work_id: work_406c25e780e295c9
@@ -71635,9 +70285,9 @@ papers:
       title: A genetically specified connectomics approach applied to long-range feeding regulatory circuits
       year: 2014
     cited_by:
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: wildenberg-2021-elife-71981
       title: Partial connectomes of labeled dopaminergic circuits reveal non-synaptic communication and axonal remodeling after exposure to cocaine
       year: 2021
@@ -71647,9 +70297,6 @@ papers:
     - id: yuan-2020-brainsci10050314
       title: Massive Data Management and Sharing Module for Connectome Reconstruction
       year: 2020
-    - id: han-2024-s41467-024-50411-z
-      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
-      year: 2024
     - id: hirabayashi-2017-s41598-018-32820-5
       title: Correlated Light-Serial Scanning Electron Microscopy (CoLSSEM) for ultrastructural visualization of single neurons in vivo
       year: 2017
@@ -72326,9 +70973,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -72602,15 +71249,12 @@ papers:
       title: Inter-individual stereotypy of the Platynereis larval visual connectome
       year: 2015
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: xu-2017-elife-25916
       title: Enhanced FIB-SEM systems for large-volume 3D imaging
       year: 2017
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: meinertzhagen-2018-jeb-164954
       title: Of what use is connectomics? A personal perspective on the Drosophila connectome
       year: 2018
@@ -72702,9 +71346,9 @@ papers:
     - id: santurkar-2017-5c63a03f
       title: Toward Streaming Synapse Detection with Compositional ConvNets
       year: 2017
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
     - id: roncal-2014-fninf-2015-00020
       title: An automated images-to-graphs framework for high resolution connectomics
       year: 2014
@@ -73341,9 +71985,6 @@ papers:
     - id: matveev-2017-3018743-3018766
       title: A Multicore Path to Connectomics-on-Demand
       year: 2017
-    - id: johnson-2019-615161
-      title: Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets
-      year: 2019
 - id: quan-2016-fcomp-2021-613981
   uuid: 10.3389/fcomp.2021.613981
   work_id: work_e38ce8eb753d5588
@@ -74468,9 +73109,6 @@ papers:
     - id: ashaber-2020-2020-03-09-984013
       title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: zheng-2017-j-cell-2018-06-019
       title: A Complete Electron Microscopy Volume of the Brain of Adult Drosophila melanogaster
       year: 2017
@@ -75515,15 +74153,12 @@ papers:
       title: Post-acquisition image based compensation for thickness variation in microscopy section series
       year: 2014
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: takemura-2023-2023-06-05-543757
       title: A Connectome of the Male Drosophila Ventral Nerve Cord
       year: 2023
-    - id: scheffer-2020-elife-57443
-      title: A connectome and analysis of the adult Drosophila central brain
-      year: 2020
     - id: zheng-2017-j-cell-2018-06-019
       title: A Complete Electron Microscopy Volume of the Brain of Adult Drosophila melanogaster
       year: 2017
@@ -75726,8 +74361,8 @@ papers:
       title: Why not connectomics?
       year: 2013
     cited_by:
-    - id: xu-2020-2020-01-21-911859
-      title: A Connectome of the Adult Drosophila Central Brain
+    - id: scheffer-2020-elife-57443
+      title: A connectome and analysis of the adult Drosophila central brain
       year: 2020
     - id: xu-2017-elife-25916
       title: Enhanced FIB-SEM systems for large-volume 3D imaging
@@ -76133,9 +74768,6 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: karlupia-2023-j-biopsych-2023-01-0
       title: Immersion fixation and staining of multi-cubic millimeter volumes for electron microscopy-based connectomics of human brain biopsies
       year: 2023
@@ -76221,9 +74853,6 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: celii-2025-s41586-025-08660-5
       title: NEURD offers automated proofreading and feature extraction for connectomics
       year: 2025
@@ -76425,9 +75054,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: shapsoncoe-2024-science-adk4858
       title: A petavoxel fragment of human cerebral cortex reconstructed at nanoscale resolution
       year: 2024
@@ -76522,7 +75151,7 @@ papers:
   year: 2015
   journal: Neural Information Processing Systems
   doi: ''
-  dimension: image-acquisition
+  dimension: segmentation
   reading_phase: 1_foundations
   role: methods
   inclusion_role: history
@@ -77650,15 +76279,12 @@ papers:
     - id: winding-2022-science-add9330
       title: The connectome of an insect brain
       year: 2022
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: zheng-2020-2020-04-17-047167
       title: Structured sampling of olfactory input by the fly mushroom body
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: schlegel-2023-2023-06-27-546055
       title: A consensus cell type atlas from multiple connectomes reveals principles of circuit stereotypy and variation
       year: 2023
@@ -78489,9 +77115,6 @@ papers:
     - id: dorkenwald-2020-s41592-021-01330-0
       title: 'FlyWire: Online community for whole-brain connectomics'
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
     - id: park-2022-fnana-2022-760279
       title: Automated Synapse Detection Method for Cerebellar Connectomics
       year: 2022
@@ -78504,9 +77127,9 @@ papers:
     - id: bae-2021-s41586-025-08790-w
       title: Functional connectomics spanning multiple areas of mouse visual cortex
       year: 2021
-    - id: januszewski-2016-6d9efa49
-      title: Flood-Filling Networks
-      year: 2016
+    - id: januszewski-2017-s41592-018-0049-4
+      title: High-precision automated reconstruction of neurons with flood-filling networks
+      year: 2017
 - id: atasoy-2014-nn-3854
   uuid: 10.1038/nn.3854
   work_id: work_71a75ab0de08abf0
@@ -79032,9 +77655,9 @@ papers:
     - id: zheng-2020-2020-04-17-047167
       title: Structured sampling of olfactory input by the fly mushroom body
       year: 2020
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
     - id: kornfeld-2017-elife-24364
       title: EM connectomics reveals axonal target variation in a sequence-generating network
       year: 2017
@@ -80052,109 +78675,6 @@ papers:
   related:
     cites: []
     cited_by: []
-- id: manton-2014-006353
-  uuid: 10.1101/006353
-  work_id: work_4396bf2e9890909a
-  title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-  authors: James D. Manton; A. S. Bates; Sridhar R. Jagannathan; Marta Costa; P. Schlegel; T. Rohlfing; G. Jefferis
-  year: 2014
-  journal: bioRxiv
-  doi: 10.1101/006353
-  dimension: methods-general
-  reading_phase: 1_foundations
-  role: methods
-  inclusion_role: history
-  k_core: 13
-  in_degree: 4
-  out_degree: 9
-  annotation_status: generated_from_pdf
-  tags:
-  - natverse
-  - drosophila
-  - r packages
-  - registration
-  - infrastructure
-  - light microscopy
-  - electron microscopy
-  ocar:
-    opportunity: Neuroanatomy is now large-scale and quantitative, so researchers need interoperable tools to read, register, visualize, cluster, and graph-analyze neurons across whole brains and imaging modalities.
-    challenge: Existing toolboxes often stop at simple morphometrics on isolated neurons, force custom code for repeated analyses, and do not compare morphology and connectivity after co-registration in a common template.
-    action: Bates, Manton, Jefferis and colleagues built the natverse, a suite of open-source R packages for local and remote neuron data, template bridging and mirroring, and integration of Drosophila light-microscopy and EM connectomic datasets.
-    resolution: The natverse supports visualization, clustering, graph-theoretic branching analysis, and transformations between template spaces. The authors demonstrate tools covering the vast majority of Drosophila neuroanatomical LM and EM datasets and deposit bridging/mirroring registrations in version-controlled GitHub repositories.
-    future_work: The suite is framed as an open platform for the community to add packages; the selected PDF is a 7 November 2019 bioRxiv version.
-  plain_language_summary: Fly brain maps now come from many labs and many microscopes, which makes comparing neurons a hassle. This software collection in R lines those maps up in shared templates so you can analyze shape and connections together.
-  summaries:
-    beginner: Fly brain maps now come from many labs and many microscopes, which makes comparing neurons a hassle. This software collection in R lines those maps up in shared templates so you can analyze shape and connections together.
-    intermediate: 'This bioRxiv preprint (version posted 7 November 2019) introduces the natverse: interoperable R packages for reading neuron data, visualization, clustering, graph analysis of arbors, and bridging between Drosophila template brains and imaging modalities, including EM connectomes. Unlike tools focused on isolated morphometrics, it emphasizes neurons in whole-brain context. Registrations are versioned on GitHub under jefferislab.'
-    advanced: The catalog year is 2014; the selected PDF is the 2019 preprint. This is a methods/software paper, not a new connectome. Claims of covering the vast majority of Drosophila LM and EM datasets are authors’ demonstrations, not an independent audit in the extract. Users still need R literacy; the paper’s pitch is reduced environment-switching, not zero code.
-  discussion_prompts:
-  - What problem in alignment, infrastructure, graph_analysis does this paper actually solve, and what would falsify that?
-  - Which dataset or organism would you trust this result on next, and why?
-  - What should a current reader still take from this paper, and what has been superseded?
-  pdf_url: https://www.biorxiv.org/content/biorxiv/early/2019/11/07/006353.full.pdf
-  pdf_status: downloaded
-  landing_url: https://doi.org/10.1101/006353
-  era: 2010–2015
-  why: history_milestone
-  citation_role: broker
-  link_strength: strong
-  year_cites_percentile: 46
-  streams:
-    axis: pipeline_stage
-    stages:
-    - alignment
-    - infrastructure
-    - graph_analysis
-    datasets: []
-    organism:
-    - fly
-    method:
-    - natverse
-    - electron microscopy
-    training_outreach: false
-    health_translation: false
-    biological_application: false
-    bridge: false
-    field_synthesis: false
-  related:
-    cites:
-    - id: takemura-2013-nature12450
-      title: A visual motion detection circuit suggested by Drosophila connectomics
-      year: 2013
-    - id: takemura-2017-elife-26975
-      title: A connectome of a learning and memory center in the adult Drosophila brain
-      year: 2017
-    - id: oh-2014-nature13186
-      title: A mesoscale connectome of the mouse brain
-      year: 2014
-    - id: schlegel-2017-j-cois-2017-09-011
-      title: Learning from connectomics on the fly.
-      year: 2017
-    - id: katz-2019-fncir-2019-00005
-      title: 'DVID: Distributed Versioned Image-Oriented Dataservice'
-      year: 2019
-    - id: schneidermizell-2015-elife-12059
-      title: Quantitative neuroanatomy for connectomics in Drosophila
-      year: 2015
-    - id: berck-2016-037721
-      title: The wiring diagram of a glomerular olfactory system
-      year: 2016
-    - id: cook-2019-s41586-019-1352-7
-      title: Whole-animal connectomes of both Caenorhabditis elegans sexes
-      year: 2019
-    cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
-      year: 2020
-    - id: clements-2020-2020-01-16-909465
-      title: 'neuPrint: Analysis Tools for EM Connectomics'
-      year: 2020
-    - id: marin-2020-2020-01-20-912709
-      title: Connectomics Analysis Reveals First-, Second-, and Third-Order Thermosensory and Hygrosensory Neurons in the Adult Drosophila Brain
-      year: 2020
-    - id: eckstein-2020-j-cell-2024-03-016
-      title: Neurotransmitter classification from electron microscopy images at synaptic sites in Drosophila melanogaster
-      year: 2020
 - id: marc-2014-fncir-2014-00104
   uuid: 10.3389/fncir.2014.00104
   work_id: work_c4b37b7d968ecae8
@@ -80517,9 +79037,9 @@ papers:
     - id: turner-2020-2020-12-11-422105
       title: The connectome predicts resting state functional connectivity across the Drosophila brain
       year: 2020
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: salova-2024-netn-a-00428
       title: Combined topological and spatial constraints are required to capture the structure of neural connectomes
       year: 2024
@@ -81353,9 +79873,6 @@ papers:
     - id: meirovitch-2016-1d0a89bd
       title: A Multi-Pass Approach to Large-Scale Connectomics
       year: 2016
-    - id: johnson-2019-615161
-      title: Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets
-      year: 2019
 - id: szalkai-2014-j-neulet-2015-03-071
   uuid: 10.1016/j.neulet.2015.03.071
   work_id: work_8ba1309e39ad81af
@@ -81767,17 +80284,14 @@ papers:
       title: '''The genetic analysis of functional connectomics in Drosophila'''
       year: 2012
     cited_by:
-    - id: li-2020-2020-08-29-273276
-      title: 'The connectome of the adult Drosophila mushroom body: implications for function'
+    - id: li-2020-elife-62576
+      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: ashaber-2020-2020-03-09-984013
       title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
       year: 2020
     - id: turner-2020-2020-12-11-422105
       title: The connectome predicts resting state functional connectivity across the Drosophila brain
-      year: 2020
-    - id: li-2020-elife-62576
-      title: The connectome of the adult Drosophila mushroom body provides insights into function
       year: 2020
     - id: hulse-2020-2020-12-08-413955
       title: A connectome of the Drosophila central complex reveals network motifs suitable for flexible navigation and context-dependent action selection
@@ -83718,9 +82232,9 @@ papers:
     - id: takemura-2017-elife-26975
       title: A connectome of a learning and memory center in the adult Drosophila brain
       year: 2017
-    - id: manton-2014-006353
-      title: 'The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data'
-      year: 2014
+    - id: bates-2020-elife-53350
+      title: The natverse, a versatile toolbox for combining and analysing neuroanatomical data
+      year: 2020
     - id: litwinkumar-2019-j-conb-2019-07-007
       title: Constraining computational models using electron microscopy wiring diagrams.
       year: 2019
@@ -86175,9 +84689,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: ashaber-2020-2020-03-09-984013
       title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
       year: 2020
@@ -86266,9 +84780,9 @@ papers:
     - id: betzel-2024-2023-10-25-562730
       title: 'Hierarchical communities in the larval Drosophila connectome: Links to cellular annotations and network topology'
       year: 2024
-    - id: han-2023-v1
-      title: Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex
-      year: 2023
+    - id: han-2024-s41467-024-50411-z
+      title: Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex
+      year: 2024
     - id: ashaber-2020-2020-03-09-984013
       title: Combined membrane potential imaging and connectome of behavioral circuits in an annelid worm
       year: 2020
@@ -87204,9 +85718,9 @@ papers:
     - id: schneidermizell-2021-elife-73783
       title: Structure and function of axo-axonic inhibition
       year: 2021
-    - id: schneidermizell-2023-2023-01-23-525290
-      title: Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex
-      year: 2023
+    - id: schneidermizell-2025-s41586-024-07780-8
+      title: Inhibitory specificity from a connectomic census of mouse visual cortex
+      year: 2025
 - id: rancz-2011-nn-2765
   uuid: 10.1038/nn.2765
   work_id: work_7aacccf8f2da1b54

--- a/content-library/journal-papers/index.md
+++ b/content-library/journal-papers/index.md
@@ -168,9 +168,9 @@ Structured records exist for the **full {{ site.data.journal_papers.papers | siz
 ```
 
 Its `dimension` values are citation-graph categories and are **not** the eleven teaching
-dimensions used on this page: `image-acquisition` (230), `connectomics` (207),
-`graph-analysis` (205), `segmentation` (142), `infrastructure` (107), `proofreading`
-(78), `neuroai` (26), `methods-general` (24), `neuroanatomy` (23), `cell-types` (22),
+dimensions used on this page: `image-acquisition` (226), `connectomics` (204),
+`graph-analysis` (203), `segmentation` (140), `infrastructure` (106), `proofreading`
+(76), `neuroai` (24), `methods-general` (23), `neuroanatomy` (23), `cell-types` (22),
 `review` (10).
 
 That enables filtering such as "every `graph-analysis` paper from before 2010, at k-core

--- a/content-library/journal-papers/methodology.md
+++ b/content-library/journal-papers/methodology.md
@@ -2,7 +2,7 @@
 layout: page
 title: "How the Paper Collection Is Built"
 permalink: /content-library/journal-papers/methodology/
-description: "How the 1,074-paper visible core was selected, what a card carries, and why views (not separate corpora) are how it's filtered."
+description: "How the 1,057-paper visible core was selected, what a card carries, and why views (not separate corpora) are how it's filtered."
 use_layout_hero: false
 content_type: core
 ---

--- a/scripts/apply_duplicate_merges.py
+++ b/scripts/apply_duplicate_merges.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Apply the adjudicated corpus fixes to _data/journal_papers.yml.
+
+Fixes 17 confirmed preprint/published duplicate-version pairs and 2 confirmed
+`dimension` mis-tags, found by an audit on 2026-08-27 (see scripts/corpus_issues.json
+for the full report, sent upstream to connectomics-survey). These are stopgap fixes
+on top of the current export -- a full from-scratch re-query is planned separately
+(see /root/.claude/plans/concept-explorer-is-very-quirky-lemon.md, Part 1B) and will
+eventually replace this file's provenance entirely.
+
+Merge rule for each pair: canonical id = the published version's DOI. The preprint's
+DOI is retained on the canonical record as `alt_dois` so old references still resolve.
+`related.cites` / `related.cited_by` are UNIONED across both records, never summed --
+several corpus papers cite both versions of a paper and would be double-counted by a
+naive sum. `in_degree` / `out_degree` are recomputed from the merged, deduplicated edge
+list (still a subset of the true graph -- see STRUCT-001 in corpus_issues.json -- but
+now at least internally consistent). `k_core` takes the max of the two source records
+pending a real whole-graph recompute.
+
+Every other record's `related.cites` / `related.cited_by` is scrubbed so no edge still
+points at a removed duplicate id -- those are repointed onto the surviving canonical id.
+
+Idempotent: running this twice is a no-op the second time, because the duplicate DOIs
+this script looks for no longer exist in the corpus after the first run.
+
+Usage:
+    python3 scripts/apply_duplicate_merges.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+PATH = ROOT / "_data" / "journal_papers.yml"
+
+# (canonical_doi, duplicate_doi, label) -- see "Dedup technique -- validation evidence"
+# in the plan doc for the author-overlap + OCAR-read adjudication behind each pair.
+MERGES = [
+    ("10.7554/elife.57443", "10.1101/2020.01.21.911859", "Hemibrain"),
+    ("10.1038/s41592-018-0049-4", "work_3de0825b6d9efa49", "Flood-filling networks"),
+    ("10.7554/elife.62576", "10.1101/2020.08.29.273276", "Mushroom body connectome"),
+    ("10.1038/s41586-021-03284-x", "10.1101/2020.05.24.112870", "C. elegans multiscale brain map"),
+    ("10.7554/elife.53350", "10.1101/006353", "natverse"),
+    ("10.1038/s41586-024-07780-8", "10.1101/2023.01.23.525290", "Inhibitory specificity"),
+    ("10.1038/s41586-024-07939-3", "10.1101/2023.03.11.532232", "Connectome-constrained networks"),
+    ("10.1038/s41593-020-0607-9", "10.1101/649731", "Recurrent architecture insect brain"),
+    ("10.1038/s41586-025-08925-z", "10.1101/2024.06.04.596633", "Comparative connectomics DN/AN"),
+    ("10.1038/s41586-024-07763-9", "10.1101/2023.05.02.539144", "Drosophila computational brain model"),
+    ("10.7554/elife.40247", "10.1101/368878", "Feeding connectome"),
+    ("10.1038/s41467-024-50411-z", "10.21203/rs.3.rs-3121892/v1", "Multiplexed volumetric CLEM"),
+    ("10.1109/tmi.2024.3400276", "10.48550/arxiv.2302.00545", "WASPSYN"),
+    ("10.1093/gigascience/giaa147", "10.1101/615161", "Scalable reproducible framework"),
+    ("10.1016/j.isci.2021.103601", "10.1101/2021.04.02.438164", "ScaleSF LM/EM"),
+    ("10.1016/j.cub.2023.12.003", "10.1101/2023.10.04.560846", "Zebrafish telencephalon"),
+    ("10.1038/s41467-026-72152-x", "10.1101/2024.12.17.628844", "Antennal grooming"),
+]
+
+# (doi, field, expected_current_value, new_value, label)
+FIELD_FIXES = [
+    ("work_ac9f66d6d45899c4", "dimension", "image-acquisition", "segmentation",
+     "Lee 2015 boundary-detection convnets"),
+    ("10.1038/s41586-021-03284-x", "dimension", "image-acquisition", "connectomics",
+     "Brittin 2021 C. elegans multiscale brain map"),
+]
+
+HEADER = """# Journal paper corpus: NeuroTrailblazers visible core.
+#
+# Generated from connectomics-survey's visible-core export
+# (source_artifact/neurotrailblazers_visible_core/). One collection
+# (1,074 papers originally; 17 preprint/published duplicate pairs merged
+# and 2 dimension mis-tags corrected 2026-08-27, see scripts/corpus_issues.json),
+# multiple views. Do not split this into a second corpus alongside
+# hand-authored teaching pages -- those pages are curated deep-dives into
+# a subset of this same collection.
+#
+# Regenerate with: python3 scripts/sync_journal_papers.py <connectomics-survey-checkout>/source_artifact/neurotrailblazers_visible_core
+# NOTE: regenerating will REVERT the 2026-08-27 duplicate merges and field
+# fixes -- re-apply scripts/apply_duplicate_merges.py after any regeneration
+# until upstream fixes these bugs (see scripts/corpus_issues.json).
+"""
+
+
+def union_edges(list_a, list_b, self_ids):
+    seen = {}
+    for edge in (list_a or []) + (list_b or []):
+        eid = edge.get("id")
+        if eid is None or eid in self_ids:
+            continue  # drop self-references between the two merged records
+        if eid not in seen:
+            seen[eid] = edge
+    return list(seen.values())
+
+
+def apply_merges(data):
+    by_uuid = {p["uuid"]: p for p in data["papers"]}
+    removed_ids = set()
+    merge_log = []
+    skipped = 0
+
+    for canon_doi, dup_doi, label in MERGES:
+        canon = by_uuid.get(canon_doi)
+        dup = by_uuid.get(dup_doi)
+        if dup is None:
+            # Already merged in a prior run (idempotent no-op), or not present.
+            skipped += 1
+            continue
+        if canon is None:
+            print(f"ERROR: canonical record missing for {label}: {canon_doi}", file=sys.stderr)
+            sys.exit(1)
+
+        canon_related = canon.get("related") or {"cites": [], "cited_by": []}
+        dup_related = dup.get("related") or {"cites": [], "cited_by": []}
+        self_ids = {canon["id"], dup["id"]}
+
+        merged_cites = union_edges(canon_related.get("cites"), dup_related.get("cites"), self_ids)
+        merged_cited_by = union_edges(canon_related.get("cited_by"), dup_related.get("cited_by"), self_ids)
+
+        before_in = len(canon_related.get("cited_by") or [])
+        canon["related"] = {"cites": merged_cites, "cited_by": merged_cited_by}
+        canon["out_degree"] = len(merged_cites)
+        canon["in_degree"] = len(merged_cited_by)
+        canon["k_core"] = max(canon.get("k_core") or 0, dup.get("k_core") or 0)
+
+        alt = canon.get("alt_dois") or []
+        if dup_doi not in alt:
+            alt.append(dup_doi)
+        canon["alt_dois"] = alt
+
+        removed_ids.add(dup["id"])
+        merge_log.append((label, before_in, canon["in_degree"]))
+
+    if skipped == len(MERGES):
+        print("All merges already applied (idempotent no-op).", file=sys.stderr)
+        return
+
+    # Repoint every other record's edges away from removed duplicate ids.
+    dup_to_canon_id = {}
+    for canon_doi, dup_doi, _label in MERGES:
+        c, d = by_uuid.get(canon_doi), by_uuid.get(dup_doi)
+        if c and d and d["id"] in removed_ids:
+            dup_to_canon_id[d["id"]] = c["id"]
+
+    id_to_title_year = {p["id"]: (p["title"], p.get("year")) for p in data["papers"]}
+
+    for p in data["papers"]:
+        if p["id"] in removed_ids:
+            continue
+        related = p.get("related") or {}
+        for key in ("cites", "cited_by"):
+            edges = related.get(key) or []
+            seen, new_edges = set(), []
+            for edge in edges:
+                eid = edge.get("id")
+                if eid in dup_to_canon_id:
+                    eid = dup_to_canon_id[eid]
+                    title, year = id_to_title_year.get(eid, (edge.get("title"), edge.get("year")))
+                    edge = {"id": eid, "title": title, "year": year}
+                if eid == p["id"] or eid in seen:
+                    continue
+                seen.add(eid)
+                new_edges.append(edge)
+            related[key] = new_edges
+        p["related"] = related
+
+    before_count = len(data["papers"])
+    data["papers"] = [p for p in data["papers"] if p["id"] not in removed_ids]
+    print(f"Merged {len(merge_log)} pairs. Papers: {before_count} -> {len(data['papers'])}", file=sys.stderr)
+    for label, before_in, after_in in merge_log:
+        print(f"  {label}: in_degree {before_in} -> {after_in}", file=sys.stderr)
+
+
+def apply_field_fixes(data):
+    by_uuid = {p["uuid"]: p for p in data["papers"]}
+    for doi, field, old, new, label in FIELD_FIXES:
+        p = by_uuid.get(doi)
+        if p is None:
+            print(f"WARNING: record not found for field fix: {label} ({doi})", file=sys.stderr)
+            continue
+        if p[field] == new:
+            continue  # already applied
+        if p[field] != old:
+            print(f"WARNING: {label}: expected {field}={old!r}, found {p[field]!r} -- skipping", file=sys.stderr)
+            continue
+        p[field] = new
+        print(f"Fixed {label}: {field} {old!r} -> {new!r}", file=sys.stderr)
+
+
+def main():
+    with open(PATH) as f:
+        data = yaml.safe_load(f)
+
+    apply_merges(data)
+    apply_field_fixes(data)
+
+    with open(PATH, "w") as f:
+        f.write(HEADER)
+        yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True, width=100000)
+
+    print(f"Wrote {PATH}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/corpus_issues.json
+++ b/scripts/corpus_issues.json
@@ -1,0 +1,1279 @@
+{
+  "report_version": 1,
+  "generated_by": "neurotrailblazers corpus audit",
+  "generated_context": "IA/knowledge-graph project preparation -- audit run against _data/journal_papers.yml before building a citation graph on top of it",
+  "upstream_target": "connectomics-survey / neurotrailblazers_visible_core (source_artifact/neurotrailblazers_visible_core/collection.json)",
+  "corpus": {
+    "name": "visible_core",
+    "records": 1074,
+    "records_after_merges": 1057
+  },
+  "summary": {
+    "duplicate_versions": 17,
+    "false_positives_documented": 3,
+    "field_errors": 6,
+    "structural_issues": 1,
+    "journal_doi_mismatches": 64,
+    "mangled_record_id_slugs": 49
+  },
+  "method": "Fuzzy title matching (Jaccard>=0.45 or containment>=0.85) over 1,074 records produced 35 candidates; each adjudicated by author-surname overlap AND by reading both OCAR action/resolution fields (not by title/author-overlap heuristics alone -- see NOTDUP-003, which clears a naive author-similarity threshold at 0.75 and is still not a duplicate). Exact and normalized title matching found zero collisions on their own.",
+  "issues": [
+    {
+      "id": "DUP-001",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Hemibrain",
+      "curated_paper": true,
+      "canonical": {
+        "uuid": "10.7554/elife.57443",
+        "record_id": "scheffer-2020-elife-57443",
+        "title": "A connectome and analysis of the adult Drosophila central brain",
+        "year": 2020,
+        "journal": "bioRxiv",
+        "in_degree": 98,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "10.1101/2020.01.21.911859",
+        "record_id": "xu-2020-2020-01-21-911859",
+        "title": "A Connectome of the Adult Drosophila Central Brain",
+        "year": 2020,
+        "journal": "bioRxiv",
+        "in_degree": 15,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 0.979,
+        "shared_authors": 95,
+        "min_author_count": 97,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2020.01.21.911859"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-002",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Flood-filling networks",
+      "curated_paper": true,
+      "canonical": {
+        "uuid": "10.1038/s41592-018-0049-4",
+        "record_id": "januszewski-2017-s41592-018-0049-4",
+        "title": "High-precision automated reconstruction of neurons with flood-filling networks",
+        "year": 2017,
+        "journal": "Nature Methods",
+        "in_degree": 60,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "work_3de0825b6d9efa49",
+        "record_id": "januszewski-2016-6d9efa49",
+        "title": "Flood-Filling Networks",
+        "year": 2016,
+        "journal": "arXiv.org",
+        "in_degree": 21,
+        "k_core": 12
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 6,
+        "min_author_count": 6,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "work_3de0825b6d9efa49"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-003",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Mushroom body connectome",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.7554/elife.62576",
+        "record_id": "li-2020-elife-62576",
+        "title": "The connectome of the adult Drosophila mushroom body provides insights into function",
+        "year": 2020,
+        "journal": "eLife",
+        "in_degree": 62,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "10.1101/2020.08.29.273276",
+        "record_id": "li-2020-2020-08-29-273276",
+        "title": "The connectome of the adult Drosophila mushroom body: implications for function",
+        "year": 2020,
+        "journal": "bioRxiv",
+        "in_degree": 7,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 24,
+        "min_author_count": 24,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2020.08.29.273276"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-004",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "C. elegans multiscale brain map",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41586-021-03284-x",
+        "record_id": "brittin-2021-s41586-021-03284-x",
+        "title": "A multiscale brain map derived from whole-brain volumetric reconstructions",
+        "year": 2021,
+        "journal": "Nature",
+        "in_degree": 33,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "10.1101/2020.05.24.112870",
+        "record_id": "brittin-2020-2020-05-24-112870",
+        "title": "Beyond the connectome: A map of a brain architecture derived from whole-brain volumetric reconstructions",
+        "year": 2020,
+        "journal": "bioRxiv",
+        "in_degree": 1,
+        "k_core": 6
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 5,
+        "min_author_count": 5,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2020.05.24.112870"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-005",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "natverse",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.7554/elife.53350",
+        "record_id": "bates-2020-elife-53350",
+        "title": "The natverse, a versatile toolbox for combining and analysing neuroanatomical data",
+        "year": 2020,
+        "journal": "eLife",
+        "in_degree": 24,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "10.1101/006353",
+        "record_id": "manton-2014-006353",
+        "title": "The natverse: a versatile computational toolbox to combine and analyse neuroanatomical data",
+        "year": 2014,
+        "journal": "bioRxiv",
+        "in_degree": 4,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 7,
+        "min_author_count": 7,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/006353"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-006",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Inhibitory specificity",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41586-024-07780-8",
+        "record_id": "schneidermizell-2025-s41586-024-07780-8",
+        "title": "Inhibitory specificity from a connectomic census of mouse visual cortex",
+        "year": 2025,
+        "journal": "Nature",
+        "in_degree": 18,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "10.1101/2023.01.23.525290",
+        "record_id": "schneidermizell-2023-2023-01-23-525290",
+        "title": "Cell-type-specific inhibitory circuitry from a connectomic census of mouse visual cortex",
+        "year": 2023,
+        "journal": "bioRxiv",
+        "in_degree": 11,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 0.976,
+        "shared_authors": 40,
+        "min_author_count": 41,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2023.01.23.525290"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-007",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Connectome-constrained networks",
+      "curated_paper": true,
+      "canonical": {
+        "uuid": "10.1038/s41586-024-07939-3",
+        "record_id": "lappalainen-2024-s41586-024-07939-3",
+        "title": "Connectome-constrained networks predict neural activity across the fly visual system",
+        "year": 2024,
+        "journal": "Nature",
+        "in_degree": 17,
+        "k_core": 11
+      },
+      "duplicate": {
+        "uuid": "10.1101/2023.03.11.532232",
+        "record_id": "lappalainen-2023-2023-03-11-532232",
+        "title": "Connectome-constrained deep mechanistic networks predict neural responses across the fly visual system at single-neuron resolution",
+        "year": 2023,
+        "journal": "bioRxiv",
+        "in_degree": 6,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 10,
+        "min_author_count": 10,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2023.03.11.532232"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-008",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Recurrent architecture insect brain",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41593-020-0607-9",
+        "record_id": "eschbach-2020-s41593-020-0607-9",
+        "title": "Recurrent architecture for adaptive regulation of learning in the insect brain",
+        "year": 2020,
+        "journal": "Nature Neuroscience",
+        "in_degree": 15,
+        "k_core": 13
+      },
+      "duplicate": {
+        "uuid": "10.1101/649731",
+        "record_id": "eschbach-2019-649731",
+        "title": "Multilevel feedback architecture for adaptive regulation of learning in the insect brain",
+        "year": 2019,
+        "journal": "bioRxiv",
+        "in_degree": 0,
+        "k_core": 3
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 16,
+        "min_author_count": 16,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/649731"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-009",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Comparative connectomics DN/AN",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41586-025-08925-z",
+        "record_id": "strner-2025-s41586-025-08925-z",
+        "title": "Comparative connectomics of Drosophila descending and ascending neurons",
+        "year": 2025,
+        "journal": "Nature",
+        "in_degree": 11,
+        "k_core": 12
+      },
+      "duplicate": {
+        "uuid": "10.1101/2024.06.04.596633",
+        "record_id": "strner-2024-2024-06-04-596633",
+        "title": "Comparative connectomics of the descending and ascending neurons of the Drosophila nervous system: stereotypy and sexual dimorphism",
+        "year": 2024,
+        "journal": "bioRxiv",
+        "in_degree": 8,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 36,
+        "min_author_count": 36,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2024.06.04.596633"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-010",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Drosophila computational brain model",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41586-024-07763-9",
+        "record_id": "shiu-2024-s41586-024-07763-9",
+        "title": "A Drosophila computational brain model reveals sensorimotor processing",
+        "year": 2024,
+        "journal": "Nature",
+        "in_degree": 8,
+        "k_core": 9
+      },
+      "duplicate": {
+        "uuid": "10.1101/2023.05.02.539144",
+        "record_id": "shiu-2023-2023-05-02-539144",
+        "title": "A leaky integrate-and-fire computational model based on the connectome of the entire adult Drosophila brain reveals insights into sensorimotor processing",
+        "year": 2023,
+        "journal": "bioRxiv",
+        "in_degree": 3,
+        "k_core": 8
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 26,
+        "min_author_count": 26,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2023.05.02.539144"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-011",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Feeding connectome",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.7554/elife.40247",
+        "record_id": "miroschnikow-2018-elife-40247",
+        "title": "Convergence of monosynaptic and polysynaptic sensory paths onto common motor outputs in a Drosophila feeding connectome",
+        "year": 2018,
+        "journal": "eLife",
+        "in_degree": 8,
+        "k_core": 12
+      },
+      "duplicate": {
+        "uuid": "10.1101/368878",
+        "record_id": "miroschnikow-2018-368878",
+        "title": "The Feeding Connectome: Convergence of Monosynaptic and Polysynaptic Sensory Paths onto Common Motor Outputs",
+        "year": 2018,
+        "journal": "bioRxiv",
+        "in_degree": 0,
+        "k_core": 6
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 10,
+        "min_author_count": 10,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/368878"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-012",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Multiplexed volumetric CLEM",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41467-024-50411-z",
+        "record_id": "han-2024-s41467-024-50411-z",
+        "title": "Multiplexed volumetric CLEM enabled by scFvs provides insights into the cytology of cerebellar cortex",
+        "year": 2024,
+        "journal": "Nature Communications",
+        "in_degree": 3,
+        "k_core": 11
+      },
+      "duplicate": {
+        "uuid": "10.21203/rs.3.rs-3121892/v1",
+        "record_id": "han-2023-v1",
+        "title": "Multiplexed volumetric CLEM enabled by antibody derivatives provides new insights into the cytology of the mouse cerebellar cortex",
+        "year": 2023,
+        "journal": "Research Square",
+        "in_degree": 0,
+        "k_core": 13
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 19,
+        "min_author_count": 19,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.21203/rs.3.rs-3121892/v1"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-013",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "WASPSYN",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1109/tmi.2024.3400276",
+        "record_id": "li-2024-tmi-2024-3400276",
+        "title": "WASPSYN: A Challenge for Domain Adaptive Synapse Detection in Microwasp Brain Connectomes",
+        "year": 2024,
+        "journal": "IEEE Transactions on Medical Imaging",
+        "in_degree": 2,
+        "k_core": 12
+      },
+      "duplicate": {
+        "uuid": "10.48550/arxiv.2302.00545",
+        "record_id": "wu-2023-arxiv-2302-00545",
+        "title": "An Out-of-Domain Synapse Detection Challenge for Microwasp Brain Connectomes",
+        "year": 2023,
+        "journal": "arXiv.org",
+        "in_degree": 0,
+        "k_core": 7
+      },
+      "evidence": {
+        "author_surname_overlap": 0.889,
+        "shared_authors": 8,
+        "min_author_count": 9,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.48550/arxiv.2302.00545"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-014",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Scalable reproducible framework",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1093/gigascience/giaa147",
+        "record_id": "johnson-2020-giaa147",
+        "title": "Toward a scalable framework for reproducible processing of volumetric, nanoscale neuroimaging datasets",
+        "year": 2020,
+        "journal": "GigaScience",
+        "in_degree": 2,
+        "k_core": 12
+      },
+      "duplicate": {
+        "uuid": "10.1101/615161",
+        "record_id": "johnson-2019-615161",
+        "title": "Toward A Reproducible, Scalable Framework for Processing Large Neuroimaging Datasets",
+        "year": 2019,
+        "journal": "bioRxiv",
+        "in_degree": 1,
+        "k_core": 9
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 17,
+        "min_author_count": 17,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/615161"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-015",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "ScaleSF LM/EM",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1016/j.isci.2021.103601",
+        "record_id": "furuta-2021-j-isci-2021-103601",
+        "title": "Multi-scale light microscopy/electron microscopy neuronal imaging from brain to synapse with a tissue clearing method, ScaleSF",
+        "year": 2021,
+        "journal": "iScience",
+        "in_degree": 1,
+        "k_core": 6
+      },
+      "duplicate": {
+        "uuid": "10.1101/2021.04.02.438164",
+        "record_id": "furuta-2021-2021-04-02-438164",
+        "title": "Title: Multi-Scale LM/EM Neuronal Imaging from Brain to Synapse with a Tissue Clearing Method, ScaleSF",
+        "year": 2021,
+        "journal": "bioRxiv",
+        "in_degree": 0,
+        "k_core": 5
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 12,
+        "min_author_count": 12,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2021.04.02.438164"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-016",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Zebrafish telencephalon",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1016/j.cub.2023.12.003",
+        "record_id": "anneser-2023-j-cub-2023-12-003",
+        "title": "Molecular organization of neuronal cell types and neuromodulatory systems in the zebrafish telencephalon",
+        "year": 2023,
+        "journal": "Current Biology",
+        "in_degree": 0,
+        "k_core": 3
+      },
+      "duplicate": {
+        "uuid": "10.1101/2023.10.04.560846",
+        "record_id": "anneser-2023-2023-10-04-560846",
+        "title": "Molecular logic of neuromodulatory systems in the zebrafish telencephalon",
+        "year": 2023,
+        "journal": "bioRxiv",
+        "in_degree": 0,
+        "k_core": 4
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 4,
+        "min_author_count": 4,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2023.10.04.560846"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "DUP-017",
+      "type": "duplicate_version",
+      "severity": "high",
+      "label": "Antennal grooming",
+      "curated_paper": false,
+      "canonical": {
+        "uuid": "10.1038/s41467-026-72152-x",
+        "record_id": "zdil-2026-s41467-026-72152-x",
+        "title": "Centralized brain networks controlling antennal grooming coordination",
+        "year": 2026,
+        "journal": "Nature Communications",
+        "in_degree": 0,
+        "k_core": 7
+      },
+      "duplicate": {
+        "uuid": "10.1101/2024.12.17.628844",
+        "record_id": "zdil-2024-2024-12-17-628844",
+        "title": "Centralized brain networks underlie body part coordination during grooming",
+        "year": 2024,
+        "journal": "bioRxiv",
+        "in_degree": 1,
+        "k_core": 1
+      },
+      "evidence": {
+        "author_surname_overlap": 1.0,
+        "shared_authors": 5,
+        "min_author_count": 5,
+        "verified_by": [
+          "author_overlap",
+          "ocar_action_and_resolution_read"
+        ]
+      },
+      "action": "merge_into_canonical",
+      "merge_rule": "union cites/cited_by edge sets then recompute in_degree/out_degree/k_core; do NOT sum degrees",
+      "retain": {
+        "alt_dois": [
+          "10.1101/2024.12.17.628844"
+        ]
+      },
+      "local_status": "merged_locally_2026-08-27"
+    },
+    {
+      "id": "NOTDUP-001",
+      "type": "near_duplicate_false_positive",
+      "severity": "info",
+      "label": "primate retina direction selectivity",
+      "uuid_a": "10.1038/s41467-022-30405-5",
+      "uuid_b": "10.1101/2021.07.21.453225",
+      "action": "keep_separate",
+      "rationale": "Zero author overlap: Dacey lab (Kim, Peterson, Crook, ... Dacey) vs Neitz lab (Patterson, Bembry, ... Neitz). Same year and topic, different groups.",
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    },
+    {
+      "id": "NOTDUP-002",
+      "type": "near_duplicate_false_positive",
+      "severity": "info",
+      "label": "neuronal boundary detection networks",
+      "uuid_a": "10.1109/iccv.2017.262",
+      "uuid_b": "work_ac9f66d6d45899c4",
+      "action": "keep_separate",
+      "rationale": "Different labs two years apart (Yuille/JHU 2017 ICCV vs Lee-Seung/Princeton 2015 NeurIPS). The ICCV paper benchmarks against VD2D/VD2D3D, the Seung-lab predecessors: a citation relationship, not identity.",
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    },
+    {
+      "id": "NOTDUP-003",
+      "type": "near_duplicate_false_positive",
+      "severity": "info",
+      "label": "FIB-SEM systems",
+      "uuid_a": "10.7554/elife.25916",
+      "uuid_b": "10.1101/852863",
+      "action": "keep_separate",
+      "rationale": "0.75 author overlap but a genuine sequel: 10^6 vs 3x10^7 um^3, stability engineering vs hot-knife partitioning, 10 authors vs 4, different specimens. NOTE: clears naive author-similarity thresholds and is still not a duplicate.",
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    },
+    {
+      "id": "FIELD-001",
+      "type": "incorrect_year",
+      "severity": "high",
+      "uuid": "10.1101/006353",
+      "record_id": "manton-2014-006353",
+      "field": "year",
+      "current": 2014,
+      "expected": 2019,
+      "evidence": "Record's own pdf_url path is biorxiv.org/content/biorxiv/early/2019/11/07/006353.full.pdf; natverse published eLife 2020.",
+      "downstream_corruption": [
+        "era",
+        "inclusion_role",
+        "why"
+      ],
+      "current_downstream": {
+        "era": "2010–2015",
+        "inclusion_role": "history",
+        "why": "history_milestone"
+      },
+      "action": "correct year, then recompute derived era/inclusion_role/why",
+      "local_status": "moot_locally_record_was_merged_away_2026-08-27_still_a_real_upstream_bug"
+    },
+    {
+      "id": "FIELD-002",
+      "type": "incorrect_dimension",
+      "severity": "medium",
+      "uuid": "work_ac9f66d6d45899c4",
+      "record_id": "lee-2015-d45899c4",
+      "field": "dimension",
+      "current": "image-acquisition",
+      "expected": "segmentation",
+      "evidence": "Lee/Seung 2015 is a neuronal boundary-detection convnet paper, not an acquisition paper.",
+      "action": "retag",
+      "local_status": "corrected_locally_2026-08-27"
+    },
+    {
+      "id": "FIELD-003",
+      "type": "incorrect_dimension",
+      "severity": "medium",
+      "uuid": "10.1038/s41586-021-03284-x",
+      "record_id": "brittin-2021-s41586-021-03284-x",
+      "field": "dimension",
+      "current": "image-acquisition",
+      "expected": "connectomics or graph-analysis",
+      "evidence": "Brittin 2021 is a circuit-architecture / connectome-variability paper, not imaging methodology. Its preprint 10.1101/2020.05.24.112870 carries the same mis-tag.",
+      "action": "retag both records",
+      "local_status": "corrected_locally_2026-08-27"
+    },
+    {
+      "id": "FIELD-004",
+      "type": "systematic_audit_requested",
+      "severity": "medium",
+      "field": [
+        "dimension",
+        "era",
+        "inclusion_role"
+      ],
+      "evidence": "3 of 4 spot-checked records carried a wrong dimension. era/inclusion_role/why are derived from year and inherit its errors (see FIELD-001).",
+      "action": "audit these derived fields corpus-wide rather than patching individual records",
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    },
+    {
+      "id": "STRUCT-001",
+      "type": "truncated_edge_lists",
+      "severity": "critical",
+      "field": [
+        "related.cites",
+        "related.cited_by"
+      ],
+      "observed": {
+        "max_list_length": 8,
+        "records_at_cap_cites": 278,
+        "records_at_cap_cited_by": 186,
+        "total_cites_edges": 4338,
+        "total_cited_by_edges": 2782,
+        "records_with_zero_cites": 174,
+        "mean_cites_per_paper": 4.0
+      },
+      "expected": "50-100 references per paper (~50,000-100,000 edges for 1,074 papers)",
+      "evidence": "Both lists cap at exactly 8 across all 1,074 records. in_degree/out_degree disagree with list lengths on 388 and 340 records respectively (e.g. Hemibrain in_degree=98 but ships 8 cited_by entries), indicating degrees are computed on a fuller graph than the one exported.",
+      "impact": "Consumers drawing a citation graph render ~5% of the real edge set while sizing nodes from the full graph. Truncation is not uniform: it disproportionately flattens the most-cited papers.",
+      "action": "raise or remove the per-record cap in the collection.json export",
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    },
+    {
+      "id": "FIELD-005",
+      "type": "journal_doi_mismatch",
+      "severity": "high",
+      "count": 64,
+      "evidence": "journal field disagrees with DOI-prefix publisher on ~106 of 1074 records (~10%), crossed in both directions.",
+      "diagnostic_note": "Likely the same root cause as the duplicate-version issue (DUP-*): fields sourced from two versions of one work rather than a formatting bug. NOT explained by this repo's backfill_journal() in sync_journal_papers.py, which only fills EMPTY journal fields and only maps 10.1101/* to bioRxiv -- these records already have a (wrong) journal value.",
+      "action": "cross-check journal against DOI-registrant for every record; treat mismatches as a second duplicate-detection signal, not merely a cosmetic fix",
+      "examples": [
+        {
+          "uuid": "10.1016/j.isci.2026.115624",
+          "record_id": "ceballos-2026-j-isci-2026-115624",
+          "doi_prefix": "10.1016",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Elsevier) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1126/science.adx2143",
+          "record_id": "cook-2025-science-adx2143",
+          "doi_prefix": "10.1126",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Science/AAAS) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.7554/elife.88824",
+          "record_id": "gruber-2025-elife-88824",
+          "doi_prefix": "10.7554",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (eLife) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1038/s41467-026-74466-2",
+          "record_id": "milisav-2025-s41467-026-74466-2",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1038/s41593-025-02080-4",
+          "record_id": "beiran-2024-s41593-025-02080-4",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1101/lm.053827.123",
+          "record_id": "fiala-2024-lm-053827-123",
+          "doi_prefix": "10.1101",
+          "journal_field": "Learning & memory (Cold Spring Harbor, N.Y.)",
+          "issue": "bioRxiv/medRxiv DOI but journal field says otherwise"
+        },
+        {
+          "uuid": "10.7554/elife.96303",
+          "record_id": "meissnerbernard-2024-elife-96303",
+          "doi_prefix": "10.7554",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (eLife) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1038/s43588-024-00735-z",
+          "record_id": "milisav-2024-s43588-024-00735-z",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1038/s41467-025-62030-3",
+          "record_id": "petkantchin-2024-s41467-025-62030-3",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1093/cercor/bhae433",
+          "record_id": "reimann-2024-bhae433",
+          "doi_prefix": "10.1093",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (OUP) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1038/s41467-024-54694-0",
+          "record_id": "reinhard-2024-s41467-024-54694-0",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1101/lm.053726.122",
+          "record_id": "sen-2024-lm-053726-122",
+          "doi_prefix": "10.1101",
+          "journal_field": "Learning & memory (Cold Spring Harbor, N.Y.)",
+          "issue": "bioRxiv/medRxiv DOI but journal field says otherwise"
+        },
+        {
+          "uuid": "10.1038/s41467-024-45971-z",
+          "record_id": "cornean-2023-s41467-024-45971-z",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1038/s41467-024-49616-z",
+          "record_id": "ganguly-2023-s41467-024-49616-z",
+          "doi_prefix": "10.1038",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Nature-family) but journal field says bioRxiv/medRxiv"
+        },
+        {
+          "uuid": "10.1016/j.isci.2024.110266",
+          "record_id": "imoto-2023-j-isci-2024-110266",
+          "doi_prefix": "10.1016",
+          "journal_field": "bioRxiv",
+          "issue": "published-journal DOI (Elsevier) but journal field says bioRxiv/medRxiv"
+        }
+      ],
+      "full_list_count": 64,
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    },
+    {
+      "id": "FIELD-006",
+      "type": "mangled_record_id_slug",
+      "severity": "low",
+      "count": 49,
+      "evidence": "record_id (the human-readable slug id, distinct from uuid/DOI) drops non-ASCII characters from first-author surnames during slugification, e.g. 'zdil-' for Özdil, 'strner-' for Stürner, 'kovcs-' for Kovács.",
+      "impact": "Cosmetic / readability only since uuid (DOI) is the join key -- but one record has an EMPTY author slug and its record_id begins with a hyphen.",
+      "action": "transliterate (NFKD strip-diacritics) rather than drop non-ASCII characters when generating record_id; ensure the empty-slug case cannot occur",
+      "examples": [
+        {
+          "uuid": "10.64898/2026.02.12.705493",
+          "record_id": "barroszulaica-2026-2026-02-12-705493",
+          "first_author": "Natalí Barros-Zulaica",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.64898/2026.06.05.730322",
+          "record_id": "fernndez-2026-2026-06-05-730322",
+          "first_author": "M. P. Fernández",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.neuroscience.2026.02.044",
+          "record_id": "lobato-2026-j-neuroscience-2026",
+          "first_author": "Fábio Lobato",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.64898/2026.05.28.727403",
+          "record_id": "strh-2026-2026-05-28-727403",
+          "first_author": "Sebastian Ströh",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1186/s12915-026-02641-4",
+          "record_id": "szilgyi-2026-s12915-026-02641-4",
+          "first_author": "Gábor Szilágyi",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s41467-026-72152-x",
+          "record_id": "zdil-2026-s41467-026-72152-x",
+          "first_author": "P. G. Özdil",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s41586-025-08925-z",
+          "record_id": "strner-2025-s41586-025-08925-z",
+          "first_author": "T. Stürner",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/2024.03.17.585258",
+          "record_id": "veraszt-2025-2024-03-17-585258",
+          "first_author": "C. Verasztó",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1145/3665318.3677154",
+          "record_id": "cal-2024-3665318-3677154",
+          "first_author": "C. Calì",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/lm.053827.123",
+          "record_id": "fiala-2024-lm-053827-123",
+          "first_author": "André Fiala",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.4103/atn.atn-d-24-00009",
+          "record_id": "lujn-2024-atn-atn-d-24-00009",
+          "first_author": "Rafael Luján",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s41596-024-00957-5",
+          "record_id": "mller-2024-s41596-024-00957-5",
+          "first_author": "A. Müller",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/2024.06.04.596633",
+          "record_id": "strner-2024-2024-06-04-596633",
+          "first_author": "T. Stürner",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s42003-024-06491-0",
+          "record_id": "turganolopez-2024-s42003-024-06491-0",
+          "first_author": "M. Turégano-Lopez",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/2024.12.17.628844",
+          "record_id": "zdil-2024-2024-12-17-628844",
+          "first_author": "P. G. Özdil",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1126/sciadv.adf3471",
+          "record_id": "cervantes-2023-sciadv-adf3471",
+          "first_author": "Diégo Cordero Cervantes",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/2023.04.06.535891",
+          "record_id": "gonzlezsegarra-2023-2023-04-06-535891",
+          "first_author": "Amanda J. González-Segarra",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s41586-023-06099-0",
+          "record_id": "hrkey-2023-s41586-023-06099-0",
+          "first_author": "S. Hürkey",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.7554/elife.89297",
+          "record_id": "patio-2023-elife-89297",
+          "first_author": "M. Patiño",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1523/eneuro.0053-22.2022",
+          "record_id": "-2022-eneuro-0053-22-2022",
+          "first_author": "Ryosuke Tanaka (田中涼介)",
+          "empty_slug": true
+        },
+        {
+          "uuid": "10.1101/2022.03.14.484348",
+          "record_id": "berlemont-2022-2022-03-14-484348",
+          "first_author": "Kévin Berlemont",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1103/physrevresearch.4.023057",
+          "record_id": "dor-2022-physrevresearch-4-02",
+          "first_author": "G. Ódor",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s41587-025-02905-4",
+          "record_id": "msaad-2022-s41587-025-02905-4",
+          "first_author": "O. M’Saad",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.neuron.2023.09.043",
+          "record_id": "ripollsnchez-2022-j-neuron-2023-09-043",
+          "first_author": "Lidia Ripoll-Sánchez",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.31234/osf.io/hqgz7",
+          "record_id": "arnatkevicit-2021-hqgz7",
+          "first_author": "A. Arnatkevic̆iūtė",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.cub.2021.03.053",
+          "record_id": "don-2021-j-cub-2021-03-053",
+          "first_author": "E. Donà",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.7554/elife.65745",
+          "record_id": "hckesfeld-2021-elife-65745",
+          "first_author": "Sebastian Hückesfeld",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1002/cne.25268",
+          "record_id": "yez-2021-cne-25268",
+          "first_author": "J. Yáñez",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1186/s13227-021-00180-3",
+          "record_id": "zpolat-2021-s13227-021-00180-3",
+          "first_author": "B. Özpolat",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/2020.05.04.076315",
+          "record_id": "kovcs-2020-2020-05-04-076315",
+          "first_author": "István A. Kovács",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/2020.08.21.260984",
+          "record_id": "veraszt-2020-2020-08-21-260984",
+          "first_author": "C. Verasztó",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.neuron.2019.10.031",
+          "record_id": "barabsi-2019-j-neuron-2019-10-031",
+          "first_author": "Dániel L. Barabási",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1101/548081",
+          "record_id": "januszewski-2019-548081",
+          "first_author": "Michał Januszewski",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1089/brain.2018.0587",
+          "record_id": "larivire-2019-brain-2018-0587",
+          "first_author": "S. Larivière",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1371/journal.pcbi.1005989",
+          "record_id": "arnatkevicit-2018-journal-pcbi-1005989",
+          "first_author": "A. Arnatkevic̆iūtė",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1371/journal.pone.0198131",
+          "record_id": "cal-2018-journal-pone-0198131",
+          "first_author": "C. Calì",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.neuron.2017.12.037",
+          "record_id": "gmnu-2018-j-neuron-2017-12-037",
+          "first_author": "R. Gămănuţ",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1140/epjst/e2018-800037-y",
+          "record_id": "hernndez-2018-e2018-800037-y",
+          "first_author": "Adrián Hernández",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1162/netn_a_00084",
+          "record_id": "petrovi-2018-netn-a-00084",
+          "first_author": "Miljan Petrović",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.7554/elife.36440",
+          "record_id": "veraszt-2018-elife-36440",
+          "first_author": "C. Verasztó",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.neuroimage.2017.07.046",
+          "record_id": "dazparra-2017-j-neuroimage-2017-07",
+          "first_author": "Antonio Díaz-Parra",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/s41592-018-0049-4",
+          "record_id": "januszewski-2017-s41592-018-0049-4",
+          "first_author": "Michał Januszewski",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/nrn.2016.182",
+          "record_id": "schrter-2017-nrn-2016-182",
+          "first_author": "Manuel S. Schröter",
+          "empty_slug": false
+        },
+        {
+          "uuid": "work_3de0825b6d9efa49",
+          "record_id": "januszewski-2016-6d9efa49",
+          "first_author": "Michał Januszewski",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.3389/fnana.2016.00110",
+          "record_id": "kisvrday-2016-fnana-2016-00110",
+          "first_author": "Z. Kisvárday",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1038/srep38424",
+          "record_id": "zamoralpez-2016-srep38424",
+          "first_author": "G. Zamora-López",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1016/j.neuron.2014.08.001",
+          "record_id": "vlezfort-2014-j-neuron-2014-08-001",
+          "first_author": "Mateo Vélez‐Fort",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.1109/iccv.2011.6126240",
+          "record_id": "reina-2011-iccv-2011-6126240",
+          "first_author": "Amelio Vázquez Reina",
+          "empty_slug": false
+        },
+        {
+          "uuid": "10.3389/fninf.2011.00007",
+          "record_id": "sugar-2011-fninf-2011-00007",
+          "first_author": "Jørgen Sugar",
+          "empty_slug": false
+        }
+      ],
+      "local_status": "not_patched_locally_awaiting_full_requery"
+    }
+  ],
+  "local_remediation_note": "This repo applied local, stopgap fixes on 2026-08-27 for the issues below that could be resolved without full re-retrieval: all 17 DUP-* merges (scripts/apply_duplicate_merges.py), and the FIELD-002/FIELD-003 dimension corrections. FIELD-001 (natverse year) became moot locally because the mis-dated record was one of the 17 merged away -- but the underlying bug is still real in your export and will keep recurring on every future regeneration until fixed upstream. STRUCT-001 (truncated edge lists) and FIELD-005 (journal/DOI mismatches) were NOT patched locally -- this repo plans a full from-scratch re-query (via Crossref) rather than continuing to patch your export, so those remain exactly as reported below. Sending this report anyway since the bugs are real for any other consumer of this export."
+}

--- a/technical-training/journal-club/graph.md
+++ b/technical-training/journal-club/graph.md
@@ -6,7 +6,7 @@ track: core-concepts-methods
 pathways:
   - technical foundation
   - shared vocabulary
-description: "The journal club collection as a citation graph: 1,074 papers, linked by which core papers they cite. Filter by k-core, era, or organism; click a node to read it; drag to rearrange."
+description: "The journal club collection as a citation graph: 1,057 papers, linked by which core papers they cite. Filter by k-core, era, or organism; click a node to read it; drag to rearrange."
 content_type: core
 ---
 


### PR DESCRIPTION
## Summary

An audit of the 1,074-paper journal corpus (`_data/journal_papers.yml`) found the same paper recorded twice under different DOIs — once as a preprint, once as the published version — for 17 pairs, including the Hemibrain connectome paper (citation count split 8/15 across its two records) and two other milestone/reading-path papers.

- Fuzzy title matching produced 35 duplicate candidates; each was adjudicated by author-surname overlap **and** by reading both records' summaries — never on overlap alone. One 0.75-overlap candidate (the FIB-SEM systems papers) turned out to be a genuine sequel, not a duplicate, which is why author overlap alone wasn't trusted for the other 34.
- Merges **union** each pair's `cites`/`cited_by` edges rather than summing them — several corpus papers cite both versions of a paper and would otherwise be double-counted — and recompute `in_degree`/`out_degree` from the merged, deduplicated edge list. The preprint DOI is retained as `alt_dois` on the surviving canonical record.
- Corpus goes 1,074 → 1,057. Verified zero dangling edge references anywhere in the corpus or in `_data/paper_views/*` after the merge.
- Also fixes two `dimension` mis-tags found during the same audit: a boundary-detection paper tagged `image-acquisition` instead of `segmentation`, and a *C. elegans* circuit-architecture paper tagged `image-acquisition` instead of `connectomics`.
- Updates the two hand-written paper-count references (`content-library/journal-papers/methodology.md`, `technical-training/journal-club/graph.md`) and the per-dimension counts in `content-library/journal-papers/index.md` to match.

`scripts/apply_duplicate_merges.py` is idempotent and reproducible — tested against a fresh copy of the original 1,074-paper file and confirmed byte-identical output to what's committed here. `scripts/corpus_issues.json` is the full audit report (27 issues total, including several not fixed in this PR: truncated citation edge lists capped at 8 per paper, 106 journal/DOI-prefix mismatches, mangled non-ASCII record-id slugs) for the `connectomics-survey` maintainers, whose export is this corpus's ultimate source.

This is a stopgap on the current export. A full from-scratch re-query (via Crossref, informed by a methodology document from the upstream source) is planned separately as follow-up work, not part of this PR.

## Test plan

- [x] `ruby scripts/validate_paper_counts.rb` — passes (96 authored across 11 dimensions, 1,057 in corpus)
- [x] `ruby scripts/validate_frontmatter.rb` — passes
- [x] `ruby scripts/validate_dictionary.rb` — passes
- [x] `ruby scripts/validate_technical_evidence.rb` — passes
- [x] Verified zero dangling `related.cites`/`related.cited_by` references across `_data/journal_papers.yml` and all of `_data/paper_views/*.json`
- [x] Verified no other file in the repo hardcodes any of the 17 removed record ids
- [x] Ran `scripts/apply_duplicate_merges.py` against a fresh copy of the pre-merge corpus and diffed the result against what's committed — byte-identical
- [ ] Full `bundle exec jekyll build` + link checkers not run in this environment (Ruby version mismatch with the pinned Gemfile, pre-existing and unrelated to this change) — the affected pages were checked by hand against the data instead


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNXkXWtaB2oWmWU2cwXKZS)_