### PR TITLE
Add conditional rendering for interactive lab module

### DIFF
--- a/_data/module_interactives.yml
+++ b/_data/module_interactives.yml
@@ -54,7 +54,6 @@ default:
   - Review assessment rubric
   - Pass checkpoint quiz
   - Complete microtask
-  - Complete annotation challenge
 modules:
   module01:
     quiz:

--- a/_includes/ui/module-interactive-lab.html
+++ b/_includes/ui/module-interactive-lab.html
@@ -6,11 +6,13 @@
 {% assign annotation = module_data.annotation | default: default_data.annotation %}
 {% assign steps = module_data.progress_steps | default: default_data.progress_steps %}
 
+{% if module_data %}
 <section class="section nt-interactive-lab" data-module-slug="{{ page.slug }}" data-quiz-pass="{{ quiz.pass_score | default: 2 }}">
   <h2>Interactive Lab</h2>
   <p>Practice in short loops: checkpoint quiz, microtask decision, and competency progress tracking.</p>
 
   <div class="cards-grid nt-interactive-grid">
+    {% if module_data.quiz %}
     <article class="card nt-interactive-card">
       <h3 class="card-title">{{ quiz.title | default: 'Checkpoint Quiz' }}</h3>
       <form class="nt-quiz-form">
@@ -32,6 +34,7 @@
       </form>
       <p class="nt-score" aria-live="polite"></p>
     </article>
+    {% endif %}
 
     <article class="card nt-interactive-card">
       <h3 class="card-title">{{ task.title | default: 'Microtask Decision' }}</h3>
@@ -97,3 +100,4 @@
     {% endif %}
   </div>
 </section>
+{% endif %}


### PR DESCRIPTION
## Summary
Added conditional rendering checks to the interactive lab module template to prevent rendering when module data is unavailable, and made the quiz card conditionally render based on quiz data existence.

## Key Changes
- Wrapped the entire interactive lab section with `{% if module_data %}` check to prevent rendering when module data is not present
- Added conditional rendering for the quiz card with `{% if module_data.quiz %}` to only display the quiz when quiz data exists
- Removed "Complete annotation challenge" from the default progress steps in module configuration

## Implementation Details
- The outer `module_data` check ensures the entire section is only rendered when module data is available, preventing errors from undefined variables
- The inner `module_data.quiz` check allows the quiz card to be optional while keeping other interactive elements (microtask, annotation challenge) always available
- These changes improve template robustness by gracefully handling missing or incomplete module configuration data

https://claude.ai/code/session_01TQJrs2hzKHNSQN8BxkQMg6